### PR TITLE
Optimize `Repository::any()` and `Repository::none()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - You can match aggregates on collections via `Formal\ORM\Specification\Child`
+- `Formal\ORM\Adapter\Repository::any()` and `::none()`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - You can match aggregates on collections via `Formal\ORM\Specification\Child`
-- `Formal\ORM\Adapter\Repository::any()` and `::none()`
+- `Formal\ORM\Adapter\Repository::any()`
 
 ### Changed
 

--- a/src/Adapter/Filesystem/Repository.php
+++ b/src/Adapter/Filesystem/Repository.php
@@ -178,6 +178,16 @@ final class Repository implements RepositoryInterface
             ->size();
     }
 
+    public function any(Specification $specification = null): bool
+    {
+        return $this->size($specification) !== 0;
+    }
+
+    public function none(Specification $specification = null): bool
+    {
+        return $this->size($specification) === 0;
+    }
+
     /**
      * @return Sequence<Aggregate>
      */

--- a/src/Adapter/Filesystem/Repository.php
+++ b/src/Adapter/Filesystem/Repository.php
@@ -180,12 +180,18 @@ final class Repository implements RepositoryInterface
 
     public function any(Specification $specification = null): bool
     {
-        return $this->size($specification) !== 0;
+        return $this
+            ->fetch($specification, null, null, 1)
+            ->first()
+            ->match(
+                static fn() => true,
+                static fn() => false,
+            );
     }
 
     public function none(Specification $specification = null): bool
     {
-        return $this->size($specification) === 0;
+        return !$this->any($specification);
     }
 
     /**

--- a/src/Adapter/Filesystem/Repository.php
+++ b/src/Adapter/Filesystem/Repository.php
@@ -189,11 +189,6 @@ final class Repository implements RepositoryInterface
             );
     }
 
-    public function none(Specification $specification = null): bool
-    {
-        return !$this->any($specification);
-    }
-
     /**
      * @return Sequence<Aggregate>
      */

--- a/src/Adapter/Repository.php
+++ b/src/Adapter/Repository.php
@@ -47,5 +47,4 @@ interface Repository
     public function size(Specification $specification = null): int;
 
     public function any(Specification $specification = null): bool;
-    public function none(Specification $specification = null): bool;
 }

--- a/src/Adapter/Repository.php
+++ b/src/Adapter/Repository.php
@@ -45,4 +45,7 @@ interface Repository
      * @return 0|positive-int
      */
     public function size(Specification $specification = null): int;
+
+    public function any(Specification $specification = null): bool;
+    public function none(Specification $specification = null): bool;
 }

--- a/src/Adapter/SQL/Repository.php
+++ b/src/Adapter/SQL/Repository.php
@@ -187,11 +187,24 @@ final class Repository implements RepositoryInterface
 
     public function any(Specification $specification = null): bool
     {
-        return $this->size($specification) !== 0;
+        $count = $this
+            ->mainTable
+            ->count($specification)
+            ->limit(1);
+
+        return ($this->connection)($count)
+            ->first()
+            ->flatMap(static fn($row) => $row->column('count'))
+            ->filter(\is_numeric(...))
+            ->map(static fn($count) => (int) $count)
+            ->match(
+                static fn($count) => $count !== 0,
+                static fn() => false,
+            );
     }
 
     public function none(Specification $specification = null): bool
     {
-        return $this->size($specification) === 0;
+        return !$this->any($specification);
     }
 }

--- a/src/Adapter/SQL/Repository.php
+++ b/src/Adapter/SQL/Repository.php
@@ -184,4 +184,14 @@ final class Repository implements RepositoryInterface
                 static fn() => 0,
             );
     }
+
+    public function any(Specification $specification = null): bool
+    {
+        return $this->size($specification) !== 0;
+    }
+
+    public function none(Specification $specification = null): bool
+    {
+        return $this->size($specification) === 0;
+    }
 }

--- a/src/Adapter/SQL/Repository.php
+++ b/src/Adapter/SQL/Repository.php
@@ -202,9 +202,4 @@ final class Repository implements RepositoryInterface
                 static fn() => false,
             );
     }
-
-    public function none(Specification $specification = null): bool
-    {
-        return !$this->any($specification);
-    }
 }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -190,12 +190,18 @@ final class Repository
 
     public function any(Specification $specification = null): bool
     {
-        return $this->size($specification) !== 0;
+        return $this->adapter->any(match ($specification) {
+            null => null,
+            default => ($this->normalizeSpecification)($specification),
+        });
     }
 
     public function none(Specification $specification = null): bool
     {
-        return $this->size($specification) === 0;
+        return $this->adapter->none(match ($specification) {
+            null => null,
+            default => ($this->normalizeSpecification)($specification),
+        });
     }
 
     /**

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -198,10 +198,7 @@ final class Repository
 
     public function none(Specification $specification = null): bool
     {
-        return $this->adapter->none(match ($specification) {
-            null => null,
-            default => ($this->normalizeSpecification)($specification),
-        });
+        return !$this->any($specification);
     }
 
     /**


### PR DESCRIPTION
Closes #6 
