### PR TITLE
Enhance collections diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Aggregates are now stored on multiple files with the `Filesystem` adapter
 - (Optional) Entities id column with the `SQL` adapter now use the Aggregate id as a value, the columns in the Aggregate column referencing these columns have been removed
+- `Formal\ORM\Raw\Aggregate\Collection::properties()` has been renamed `::entities()`
 
 ## 1.2.0 - 2024-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 
 - You can match aggregates on collections via `Formal\ORM\Specification\Child`
 - `Formal\ORM\Adapter\Repository::any()`
+- Collections are now diffed when updating an Aggregate to only insert the new entities instead of writing everything each time
+    - internally it uses an _entity reference_ but it doesn't impact user classes
 
 ### Changed
 
 - Aggregates are now stored on multiple files with the `Filesystem` adapter
 - (Optional) Entities id column with the `SQL` adapter now use the Aggregate id as a value, the columns in the Aggregate column referencing these columns have been removed
 - `Formal\ORM\Raw\Aggregate\Collection::properties()` has been renamed `::entities()`
+- Collection tables now have an `entityReference` column
 
 ## 1.2.0 - 2024-01-15
 

--- a/documentation/limitations.md
+++ b/documentation/limitations.md
@@ -1,5 +1,5 @@
 # Limitations
 
-Due to the current design of entities not having ids it is not possible to build a diff of collections of entities. This means that as soon as a collection is modified the whole collection is persisted to the storage.
+Due to the current design of entities not having ids it is not possible to build a complete diff of collections of entities. This means that as soon as an entity is modified the whole object is persisted to the storage.
 
-For small sets of entities this is fine but can become quite time consuming if you store a lot of data inside a given collection.
+For small entities this is fine but can become quite time consuming if you store a lot of data inside a given entity.

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -37,7 +37,7 @@ return static function() {
                     CREATE TABLE  `user_billingAddress` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`id`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_addresses` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    CREATE TABLE  `user_addresses` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `entityReference` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE)
                     SQL,
                 ])
                 ->same($queries);

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -37,7 +37,7 @@ return static function() {
                     CREATE TABLE  `user_billingAddress` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`id`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_addresses` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `entityReference` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    CREATE TABLE  `user_addresses` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `entityReference` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`entityReference`), CONSTRAINT `FK_user_addresses` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE)
                     SQL,
                 ])
                 ->same($queries);

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -37,7 +37,7 @@ return static function() {
                     CREATE TABLE  `user_billingAddress` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`id`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_addresses` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `entityReference` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`entityReference`), CONSTRAINT `FK_user_addresses` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    CREATE TABLE  `user_addresses` (`entityReference` varchar(36) NOT NULL  COMMENT 'UUID', `id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`entityReference`), CONSTRAINT `FK_user_addresses` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE)
                     SQL,
                 ])
                 ->same($queries);

--- a/properties/AddElementToCollections.php
+++ b/properties/AddElementToCollections.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types = 1);
+
+namespace Properties\Formal\ORM;
+
+use Formal\ORM\{
+    Manager,
+    Id,
+    Definition\Type\PointInTimeType\Format,
+};
+use Fixtures\Formal\ORM\User;
+use Innmind\BlackBox\{
+    Set,
+    Property,
+    Runner\Assert,
+};
+use Innmind\Immutable\Either;
+use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
+
+/**
+ * @implements Property<Manager>
+ */
+final class AddElementToCollections implements Property
+{
+    private $createdAt;
+    private string $address;
+
+    private function __construct(
+        $createdAt,
+        string $address,
+    ) {
+        $this->createdAt = $createdAt;
+        $this->address = $address;
+    }
+
+    public static function any(): Set
+    {
+        return Set\Composite::immutable(
+            static fn(...$args) => new self(...$args),
+            PointInTime::any(),
+            Set\Strings::madeOf(Set\Chars::alphanumerical()),
+        );
+    }
+
+    public function applicableTo(object $manager): bool
+    {
+        return true;
+    }
+
+    public function ensureHeldBy(Assert $assert, object $manager): object
+    {
+        $repository = $manager->repository(User::class);
+        $user = User::new($this->createdAt);
+
+        $manager->transactional(
+            fn() => Either::right(
+                $repository
+                    ->all()
+                    ->map(fn($user) => $user->addAddress($this->address))
+                    ->foreach($repository->put(...)),
+            ),
+        );
+
+        $repository
+            ->all()
+            ->foreach(fn($user) => $assert->true(
+                $user
+                    ->addresses()
+                    ->map(static fn($address) => $address->toString())
+                    ->contains($this->address),
+            ));
+
+        return $manager;
+    }
+}

--- a/properties/IncrementallyAddElementsToACollection.php
+++ b/properties/IncrementallyAddElementsToACollection.php
@@ -14,7 +14,6 @@ use Innmind\BlackBox\{
     Property,
     Runner\Assert,
 };
-use Innmind\TimeContinuum\Earth\Timezone\UTC;
 use Innmind\Immutable\Either;
 use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
 

--- a/properties/IncrementallyAddElementsToACollection.php
+++ b/properties/IncrementallyAddElementsToACollection.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types = 1);
+
+namespace Properties\Formal\ORM;
+
+use Formal\ORM\{
+    Manager,
+    Id,
+    Definition\Type\PointInTimeType\Format,
+};
+use Fixtures\Formal\ORM\User;
+use Innmind\BlackBox\{
+    Set,
+    Property,
+    Runner\Assert,
+};
+use Innmind\TimeContinuum\Earth\Timezone\UTC;
+use Innmind\Immutable\Either;
+use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
+
+/**
+ * @implements Property<Manager>
+ */
+final class IncrementallyAddElementsToACollection implements Property
+{
+    private $createdAt;
+    private array $addresses;
+
+    private function __construct(
+        $createdAt,
+        array $addresses,
+    ) {
+        $this->createdAt = $createdAt;
+        $this->addresses = $addresses;
+    }
+
+    public static function any(): Set
+    {
+        return Set\Composite::immutable(
+            static fn(...$args) => new self(...$args),
+            PointInTime::any(),
+            Set\Sequence::of(
+                Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            )->atLeast(1),
+        );
+    }
+
+    public function applicableTo(object $manager): bool
+    {
+        return true;
+    }
+
+    public function ensureHeldBy(Assert $assert, object $manager): object
+    {
+        $repository = $manager->repository(User::class);
+        $user = User::new($this->createdAt);
+
+        $manager->transactional(
+            static fn() => Either::right($repository->put($user)),
+        );
+        $id = $user->id()->toString();
+        unset($user); // to make sure there is no in memory cache somewhere
+
+        foreach ($this->addresses as $index => $address) {
+            $manager->transactional(
+                static function() use ($assert, $repository, $index, $address, $id) {
+                    $user = $repository->get(Id::of(User::class, $id))->match(
+                        static fn($user) => $user,
+                        static fn() => null,
+                    );
+
+                    $assert->not()->null($user);
+                    $assert->count(
+                        $index,
+                        $user->addresses(),
+                        'Previous addresses have been lost',
+                    );
+                    $repository->put($user->addAddress($address));
+
+                    return Either::right(null);
+                },
+            );
+        }
+
+        return $manager;
+    }
+}

--- a/properties/ListingAggregatesUseConstantMemory.php
+++ b/properties/ListingAggregatesUseConstantMemory.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types = 1);
+declare(ticks = 1);
+
+namespace Properties\Formal\ORM;
+
+use Formal\ORM\{
+    Manager,
+};
+use Fixtures\Formal\ORM\User;
+use Innmind\BlackBox\{
+    Set,
+    Property,
+    Runner\Assert,
+};
+use Innmind\Immutable\Either;
+use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
+
+/**
+ * @implements Property<Manager>
+ */
+final class ListingAggregatesUseConstantMemory implements Property
+{
+    private function __construct()
+    {
+    }
+
+    public static function any(): Set
+    {
+        return Set\Elements::of(new self);
+    }
+
+    public function applicableTo(object $manager): bool
+    {
+        return true;
+    }
+
+    public function ensureHeldBy(Assert $assert, object $manager): object
+    {
+        $repository = $manager->repository(User::class);
+
+        $assert
+            ->memory(
+                static function() use ($repository) {
+                    $_ = $repository
+                        ->all()
+                        ->foreach(static fn() => null);
+                },
+            )
+            ->inLessThan()
+            ->megaBytes(1);
+
+        return $manager;
+    }
+}

--- a/properties/ListingAggregatesUseConstantMemory.php
+++ b/properties/ListingAggregatesUseConstantMemory.php
@@ -4,17 +4,13 @@ declare(ticks = 1);
 
 namespace Properties\Formal\ORM;
 
-use Formal\ORM\{
-    Manager,
-};
+use Formal\ORM\Manager;
 use Fixtures\Formal\ORM\User;
 use Innmind\BlackBox\{
     Set,
     Property,
     Runner\Assert,
 };
-use Innmind\Immutable\Either;
-use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
 
 /**
  * @implements Property<Manager>

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -58,6 +58,7 @@ final class Properties
             AddingOutsideOfTransactionIsNotAllowed::class,
             UpdatingOutsideOfTransactionIsNotAllowed::class,
             RemovingOutsideOfTransactionIsNotAllowed::class,
+            IncrementallyAddElementsToACollection::class,
         ];
     }
 
@@ -96,6 +97,7 @@ final class Properties
             FailingTransactionDueToException::class,
             DroppingMoreElementsThanWasTakenReturnsNothing::class,
             AddingOutsideOfTransactionIsNotAllowed::class,
+            IncrementallyAddElementsToACollection::class,
         ];
     }
 }

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -59,6 +59,7 @@ final class Properties
             UpdatingOutsideOfTransactionIsNotAllowed::class,
             RemovingOutsideOfTransactionIsNotAllowed::class,
             IncrementallyAddElementsToACollection::class,
+            AddElementToCollections::class,
         ];
     }
 

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -60,6 +60,7 @@ final class Properties
             RemovingOutsideOfTransactionIsNotAllowed::class,
             IncrementallyAddElementsToACollection::class,
             AddElementToCollections::class,
+            ListingAggregatesUseConstantMemory::class,
         ];
     }
 

--- a/src/Adapter/Filesystem/Decode.php
+++ b/src/Adapter/Filesystem/Decode.php
@@ -129,10 +129,12 @@ final class Decode
                             static fn($collection) => Aggregate\Collection::of(
                                 $collection->name()->toString(),
                                 Set::of(...Json::decode($collection->content()->toString()))->map(
-                                    static fn($entity) => Set::of(...$entity)->map(
-                                        static fn($property) => Aggregate\Property::of(
-                                            $property[0],
-                                            $property[1],
+                                    static fn($entity) => Aggregate\Collection\Entity::of(
+                                        Set::of(...$entity)->map(
+                                            static fn($property) => Aggregate\Property::of(
+                                                $property[0],
+                                                $property[1],
+                                            ),
                                         ),
                                     ),
                                 ),

--- a/src/Adapter/Filesystem/Decode.php
+++ b/src/Adapter/Filesystem/Decode.php
@@ -131,8 +131,8 @@ final class Decode
                                 $collection->name()->toString(),
                                 Set::of(...Json::decode($collection->content()->toString()))->map(
                                     static fn($entity) => Aggregate\Collection\Entity::of(
-                                        Reference::new(),
-                                        Set::of(...$entity)->map(
+                                        Reference::of($entity['reference']),
+                                        Set::of(...$entity['properties'])->map(
                                             static fn($property) => Aggregate\Property::of(
                                                 $property[0],
                                                 $property[1],

--- a/src/Adapter/Filesystem/Decode.php
+++ b/src/Adapter/Filesystem/Decode.php
@@ -6,6 +6,7 @@ namespace Formal\ORM\Adapter\Filesystem;
 use Formal\ORM\{
     Definition\Aggregate as Definition,
     Raw\Aggregate,
+    Raw\Aggregate\Collection\Entity\Reference,
 };
 use Innmind\Filesystem\{
     File,
@@ -130,6 +131,7 @@ final class Decode
                                 $collection->name()->toString(),
                                 Set::of(...Json::decode($collection->content()->toString()))->map(
                                     static fn($entity) => Aggregate\Collection\Entity::of(
+                                        Reference::new(),
                                         Set::of(...$entity)->map(
                                             static fn($property) => Aggregate\Property::of(
                                                 $property[0],

--- a/src/Adapter/Filesystem/Encode.php
+++ b/src/Adapter/Filesystem/Encode.php
@@ -93,6 +93,10 @@ final class Encode
                 // dedicated directory/file but there is currently no way to
                 // tell the filesystem to erase all files in a directory before
                 // persisting the new version.
+                // We don't need to persist the reference of each entity as their
+                // purpose is to persist the smallest diff possible, but since
+                // we store the whole collection each time no need to diff via
+                // the references.
                 $data
                     ->collections()
                     ->map(
@@ -100,7 +104,7 @@ final class Encode
                             $collection->name(),
                             Content::ofString(Json::encode(
                                 $collection
-                                    ->newEntities()
+                                    ->entities()
                                     ->map(
                                         static fn($entity) => $entity
                                             ->properties()

--- a/src/Adapter/Filesystem/Encode.php
+++ b/src/Adapter/Filesystem/Encode.php
@@ -100,9 +100,9 @@ final class Encode
                             $collection->name(),
                             Content::ofString(Json::encode(
                                 $collection
-                                    ->properties()
+                                    ->entities()
                                     ->map(
-                                        static fn($properties) => $properties
+                                        static fn($entity) => $entity
                                             ->map(static fn($property) => [
                                                 $property->name(),
                                                 $property->value(),

--- a/src/Adapter/Filesystem/Encode.php
+++ b/src/Adapter/Filesystem/Encode.php
@@ -103,6 +103,7 @@ final class Encode
                                     ->entities()
                                     ->map(
                                         static fn($entity) => $entity
+                                            ->properties()
                                             ->map(static fn($property) => [
                                                 $property->name(),
                                                 $property->value(),

--- a/src/Adapter/Filesystem/Encode.php
+++ b/src/Adapter/Filesystem/Encode.php
@@ -93,10 +93,6 @@ final class Encode
                 // dedicated directory/file but there is currently no way to
                 // tell the filesystem to erase all files in a directory before
                 // persisting the new version.
-                // We don't need to persist the reference of each entity as their
-                // purpose is to persist the smallest diff possible, but since
-                // we store the whole collection each time no need to diff via
-                // the references.
                 $data
                     ->collections()
                     ->map(
@@ -106,13 +102,16 @@ final class Encode
                                 $collection
                                     ->entities()
                                     ->map(
-                                        static fn($entity) => $entity
-                                            ->properties()
-                                            ->map(static fn($property) => [
-                                                $property->name(),
-                                                $property->value(),
-                                            ])
-                                            ->toList(),
+                                        static fn($entity) => [
+                                            'reference' => $entity->reference()->toString(),
+                                            'properties' => $entity
+                                                ->properties()
+                                                ->map(static fn($property) => [
+                                                    $property->name(),
+                                                    $property->value(),
+                                                ])
+                                                ->toList(),
+                                        ],
                                     )
                                     ->toList(),
                             )),

--- a/src/Adapter/Filesystem/Encode.php
+++ b/src/Adapter/Filesystem/Encode.php
@@ -100,7 +100,7 @@ final class Encode
                             $collection->name(),
                             Content::ofString(Json::encode(
                                 $collection
-                                    ->entities()
+                                    ->newEntities()
                                     ->map(
                                         static fn($entity) => $entity
                                             ->properties()

--- a/src/Adapter/Filesystem/Fold.php
+++ b/src/Adapter/Filesystem/Fold.php
@@ -164,7 +164,6 @@ final class Fold
             $left = $this->child($specification->left());
             $right = $this->child($specification->right());
 
-            /** @psalm-suppress MixedArgumentTypeCoercion */
             return match ($specification->operator()) {
                 Operator::and => static fn(Aggregate\Collection\Entity $entity) => $left($entity) && $right($entity),
                 Operator::or => static fn(Aggregate\Collection\Entity $entity) => $left($entity) || $right($entity),

--- a/src/Adapter/Filesystem/Fold.php
+++ b/src/Adapter/Filesystem/Fold.php
@@ -18,7 +18,6 @@ use Innmind\Specification\{
     Operator,
     Sign,
 };
-use Innmind\Immutable\Set;
 
 /**
  * @internal
@@ -151,14 +150,14 @@ final class Fold
     }
 
     /**
-     * @return callable(Set<Aggregate\Property>): bool
+     * @return callable(Aggregate\Collection\Entity): bool
      */
     private function child(Specification $specification): callable
     {
         if ($specification instanceof Not) {
             $filter = $this->child($specification->specification());
 
-            return static fn(Set $properties) => !$filter($properties);
+            return static fn(Aggregate\Collection\Entity $entity) => !$filter($entity);
         }
 
         if ($specification instanceof Composite) {
@@ -167,8 +166,8 @@ final class Fold
 
             /** @psalm-suppress MixedArgumentTypeCoercion */
             return match ($specification->operator()) {
-                Operator::and => static fn(Set $properties) => $left($properties) && $right($properties),
-                Operator::or => static fn(Set $properties) => $left($properties) || $right($properties),
+                Operator::and => static fn(Aggregate\Collection\Entity $entity) => $left($entity) && $right($entity),
+                Operator::or => static fn(Aggregate\Collection\Entity $entity) => $left($entity) || $right($entity),
             };
         }
 
@@ -180,7 +179,8 @@ final class Fold
 
         $filter = $this->filter($specification);
 
-        return static fn(Set $entity) => $entity
+        return static fn(Aggregate\Collection\Entity $entity) => $entity
+            ->properties()
             ->find(static fn($property) => $property->name() === $specification->property())
             ->match(
                 static fn($property) => $filter($property->value()),

--- a/src/Adapter/Filesystem/Fold.php
+++ b/src/Adapter/Filesystem/Fold.php
@@ -83,7 +83,7 @@ final class Fold
                 ->find(static fn($collection) => $collection->name() === $specification->collection())
                 ->flatMap(
                     static fn($collection) => $collection
-                        ->entities()
+                        ->newEntities()
                         ->find($filter),
                 )
                 ->match(

--- a/src/Adapter/Filesystem/Fold.php
+++ b/src/Adapter/Filesystem/Fold.php
@@ -83,7 +83,7 @@ final class Fold
                 ->find(static fn($collection) => $collection->name() === $specification->collection())
                 ->flatMap(
                     static fn($collection) => $collection
-                        ->newEntities()
+                        ->entities()
                         ->find($filter),
                 )
                 ->match(

--- a/src/Adapter/Filesystem/Fold.php
+++ b/src/Adapter/Filesystem/Fold.php
@@ -84,7 +84,7 @@ final class Fold
                 ->find(static fn($collection) => $collection->name() === $specification->collection())
                 ->flatMap(
                     static fn($collection) => $collection
-                        ->properties()
+                        ->entities()
                         ->find($filter),
                 )
                 ->match(
@@ -180,7 +180,7 @@ final class Fold
 
         $filter = $this->filter($specification);
 
-        return static fn(Set $properties) => $properties
+        return static fn(Set $entity) => $entity
             ->find(static fn($property) => $property->name() === $specification->property())
             ->match(
                 static fn($property) => $filter($property->value()),

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -170,24 +170,30 @@ final class CollectionTable
     /**
      * @internal
      *
-     * @param Set<Entity> $collection
+     * @param Set<Entity> $newEntities
+     * @param Set<Entity\Reference> $unmodifiedEntities
      *
      * @return Sequence<Query>
      */
-    public function update(Id $id, Set $collection): Sequence
-    {
+    public function update(
+        Id $id,
+        Set $newEntities,
+        Set $unmodifiedEntities,
+    ): Sequence {
         return Sequence::of(
-            Delete::from($this->name)->where(PropertySpecification::of(
-                \sprintf(
-                    '%s.%s',
-                    $this->name->alias(),
-                    $this->id->column()->toString(),
+            Delete::from($this->name)->where(
+                PropertySpecification::of(
+                    \sprintf(
+                        '%s.%s',
+                        $this->name->alias(),
+                        $this->id->column()->toString(),
+                    ),
+                    Sign::equality,
+                    $id->value(),
                 ),
-                Sign::equality,
-                $id->value(),
-            )),
+            ),
             ...$this
-                ->insert($id, $collection)
+                ->insert($id, $newEntities)
                 ->toSequence()
                 ->toList(),
         );

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -14,7 +14,6 @@ use Formal\AccessLayer\{
     Table\Column,
     Query,
     Query\Select,
-    Query\Update,
     Query\Delete,
     Row,
 };
@@ -149,12 +148,12 @@ final class CollectionTable
                     $table,
                     ...$collection
                         ->map(
-                            static fn($properties) => new Row(
+                            static fn($entity) => new Row(
                                 new Row\Value(
                                     Column\Name::of('id')->in($table),
                                     $id->value(),
                                 ),
-                                ...$properties
+                                ...$entity
                                     ->map(static fn($property) => new Row\Value(
                                         Column\Name::of($property->name())->in($table),
                                         $property->value(),

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -60,6 +60,7 @@ final class CollectionTable
         $this->reference = Column\Name::of('entityReference')->in($this->name);
         $this->select = Select::from($this->name)->columns(
             $this->id,
+            $this->reference,
             ...$this->columns->toList(),
         );
     }

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -6,7 +6,7 @@ namespace Formal\ORM\Adapter\SQL;
 use Formal\ORM\{
     Definition\Aggregate\Collection as Definition,
     Raw\Aggregate\Id,
-    Raw\Aggregate\Property,
+    Raw\Aggregate\Collection\Entity,
     Specification\Property as PropertySpecification,
 };
 use Formal\AccessLayer\{
@@ -132,7 +132,7 @@ final class CollectionTable
     /**
      * @internal
      *
-     * @param Set<Set<Property>> $collection
+     * @param Set<Entity> $collection
      *
      * @return Maybe<Query>
      */
@@ -154,6 +154,7 @@ final class CollectionTable
                                     $id->value(),
                                 ),
                                 ...$entity
+                                    ->properties()
                                     ->map(static fn($property) => new Row\Value(
                                         Column\Name::of($property->name())->in($table),
                                         $property->value(),
@@ -169,7 +170,7 @@ final class CollectionTable
     /**
      * @internal
      *
-     * @param Set<Set<Property>> $collection
+     * @param Set<Entity> $collection
      *
      * @return Sequence<Query>
      */

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -83,15 +83,15 @@ final class CollectionTable
     public function primaryKey(): Table\Column
     {
         return Table\Column::of(
-            Table\Column\Name::of('id'),
+            Table\Column\Name::of('entityReference'),
             Table\Column\Type::varchar(36)->comment('UUID'),
         );
     }
 
-    public function referenceColumn(): Table\Column
+    public function foreignKey(): Table\Column
     {
         return Table\Column::of(
-            Table\Column\Name::of('entityReference'),
+            Table\Column\Name::of('id'),
             Table\Column\Type::varchar(36)->comment('UUID'),
         );
     }

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -119,6 +119,7 @@ final class Decode
                                     $row,
                                     $collection->columns(),
                                 ))
+                                ->map(Aggregate\Collection\Entity::of(...))
                                 ->toSet()
                                 ->memoize();
                         })(),

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -24,8 +24,6 @@ use Innmind\Immutable\{
  */
 final class Decode
 {
-    /** @var Definition<T> */
-    private Definition $definition;
     /** @var MainTable<T> */
     private MainTable $mainTable;
     private Connection $connection;
@@ -43,7 +41,6 @@ final class Decode
         MainTable $mainTable,
         Connection $connection,
     ) {
-        $this->definition = $definition;
         $this->mainTable = $mainTable;
         $this->connection = $connection;
         $this->entityPrefix = $mainTable->name()->alias().'_';

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -113,13 +113,18 @@ final class Decode
                             // The memoize is here to make sure the user can't
                             // work with a partially loaded collection
                             yield ($this->connection)($collection->select($id))
-                                ->map(static fn($row) => self::properties(
-                                    $row,
-                                    $collection->columns(),
-                                ))
-                                ->map(static fn($entity) => Aggregate\Collection\Entity::of(
-                                    Reference::new(),
-                                    $entity,
+                                ->map(static fn($row) => Aggregate\Collection\Entity::of(
+                                    $row
+                                        ->column($collection->referenceColumn()->name()->toString())
+                                        ->filter(\is_string(...))
+                                        ->match(
+                                            Reference::of(...),
+                                            static fn() => throw new \RuntimeException('Invalid entity reference'),
+                                        ),
+                                    self::properties(
+                                        $row,
+                                        $collection->columns(),
+                                    ),
                                 ))
                                 ->toSet()
                                 ->memoize();

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -115,7 +115,7 @@ final class Decode
                             yield ($this->connection)($collection->select($id))
                                 ->map(static fn($row) => Aggregate\Collection\Entity::of(
                                     $row
-                                        ->column($collection->referenceColumn()->name()->toString())
+                                        ->column($collection->primaryKey()->name()->toString())
                                         ->filter(\is_string(...))
                                         ->match(
                                             Reference::of(...),

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -6,6 +6,7 @@ namespace Formal\ORM\Adapter\SQL;
 use Formal\ORM\{
     Definition\Aggregate as Definition,
     Raw\Aggregate,
+    Raw\Aggregate\Collection\Entity\Reference,
 };
 use Formal\AccessLayer\{
     Connection,
@@ -116,7 +117,10 @@ final class Decode
                                     $row,
                                     $collection->columns(),
                                 ))
-                                ->map(Aggregate\Collection\Entity::of(...))
+                                ->map(static fn($entity) => Aggregate\Collection\Entity::of(
+                                    Reference::new(),
+                                    $entity,
+                                ))
                                 ->toSet()
                                 ->memoize();
                         })(),

--- a/src/Adapter/SQL/Encode.php
+++ b/src/Adapter/SQL/Encode.php
@@ -134,7 +134,7 @@ final class Encode
                     ->flatMap(
                         static fn($table) => $table->insert(
                             $data->id(),
-                            $collection->entities(),
+                            $collection->newEntities(),
                         ),
                     )
                     ->toSequence()

--- a/src/Adapter/SQL/Encode.php
+++ b/src/Adapter/SQL/Encode.php
@@ -134,7 +134,7 @@ final class Encode
                     ->flatMap(
                         static fn($table) => $table->insert(
                             $data->id(),
-                            $collection->newEntities(),
+                            $collection->entities(),
                         ),
                     )
                     ->toSequence()

--- a/src/Adapter/SQL/Encode.php
+++ b/src/Adapter/SQL/Encode.php
@@ -134,7 +134,7 @@ final class Encode
                     ->flatMap(
                         static fn($table) => $table->insert(
                             $data->id(),
-                            $collection->properties(),
+                            $collection->entities(),
                         ),
                     )
                     ->toSequence()

--- a/src/Adapter/SQL/ShowCreateTable.php
+++ b/src/Adapter/SQL/ShowCreateTable.php
@@ -84,21 +84,21 @@ final class ShowCreateTable
                 fn($collection) => Query\CreateTable::named(
                     $collection->name()->name(),
                     $collection->primaryKey(),
-                    $collection->referenceColumn(),
+                    $collection->foreignKey(),
                     ...$collection
                         ->columnsDefinition($this->mapType)
                         ->toList(),
                 )
-                    ->primaryKey($collection->referenceColumn()->name())
+                    ->primaryKey($collection->primaryKey()->name())
                     ->constraint(
                         ForeignKey::of(
-                            $collection->primaryKey()->name(),
+                            $collection->foreignKey()->name(),
                             $mainTable->name()->name(),
                             $mainTable->primaryKey()->name(),
                         )
                             ->onDeleteCascade()
                             ->named($collection->name()->name()->toString()),
-                    )
+                    ),
             )
             ->toList();
 

--- a/src/Adapter/SQL/ShowCreateTable.php
+++ b/src/Adapter/SQL/ShowCreateTable.php
@@ -80,22 +80,26 @@ final class ShowCreateTable
 
         $collections = $mainTable
             ->collections()
-            ->map(fn($collection) => Query\CreateTable::named(
-                $collection->name()->name(),
-                $collection->primaryKey(),
-                $collection->referenceColumn(),
-                ...$collection
-                    ->columnsDefinition($this->mapType)
-                    ->toList(),
-            )->constraint(
-                ForeignKey::of(
-                    $collection->primaryKey()->name(),
-                    $mainTable->name()->name(),
-                    $mainTable->primaryKey()->name(),
+            ->map(
+                fn($collection) => Query\CreateTable::named(
+                    $collection->name()->name(),
+                    $collection->primaryKey(),
+                    $collection->referenceColumn(),
+                    ...$collection
+                        ->columnsDefinition($this->mapType)
+                        ->toList(),
                 )
-                    ->onDeleteCascade()
-                    ->named($collection->name()->name()->toString()),
-            ))
+                    ->primaryKey($collection->referenceColumn()->name())
+                    ->constraint(
+                        ForeignKey::of(
+                            $collection->primaryKey()->name(),
+                            $mainTable->name()->name(),
+                            $mainTable->primaryKey()->name(),
+                        )
+                            ->onDeleteCascade()
+                            ->named($collection->name()->name()->toString()),
+                    )
+            )
             ->toList();
 
         $main = Query\CreateTable::named(

--- a/src/Adapter/SQL/ShowCreateTable.php
+++ b/src/Adapter/SQL/ShowCreateTable.php
@@ -83,6 +83,7 @@ final class ShowCreateTable
             ->map(fn($collection) => Query\CreateTable::named(
                 $collection->name()->name(),
                 $collection->primaryKey(),
+                $collection->referenceColumn(),
                 ...$collection
                     ->columnsDefinition($this->mapType)
                     ->toList(),

--- a/src/Adapter/SQL/Update.php
+++ b/src/Adapter/SQL/Update.php
@@ -69,7 +69,7 @@ final class Update
                     ->collection($collection->name())
                     ->map(static fn($table) => $table->update(
                         $data->id(),
-                        $collection->properties(),
+                        $collection->entities(),
                     ))
                     ->toSequence()
                     ->toSet(),

--- a/src/Adapter/SQL/Update.php
+++ b/src/Adapter/SQL/Update.php
@@ -69,7 +69,7 @@ final class Update
                     ->collection($collection->name())
                     ->map(static fn($table) => $table->update(
                         $data->id(),
-                        $collection->entities(),
+                        $collection->newEntities(),
                     ))
                     ->toSequence()
                     ->toSet(),

--- a/src/Adapter/SQL/Update.php
+++ b/src/Adapter/SQL/Update.php
@@ -70,6 +70,9 @@ final class Update
                     ->map(static fn($table) => $table->update(
                         $data->id(),
                         $collection->newEntities(),
+                        $collection->unmodifiedEntities()->map(
+                            static fn($entity) => $entity->reference(),
+                        ),
                     ))
                     ->toSequence()
                     ->toSet(),

--- a/src/Raw/Aggregate/Collection.php
+++ b/src/Raw/Aggregate/Collection.php
@@ -15,15 +15,22 @@ final class Collection
     private string $name;
     /** @var Set<Entity> */
     private Set $newEntities;
+    /** @var Set<Entity> */
+    private Set $unmodifiedEntities;
 
     /**
      * @param non-empty-string $name
      * @param Set<Entity> $newEntities
+     * @param Set<Entity> $unmodifiedEntities
      */
-    private function __construct(string $name, Set $newEntities)
-    {
+    private function __construct(
+        string $name,
+        Set $newEntities,
+        Set $unmodifiedEntities,
+    ) {
         $this->name = $name;
         $this->newEntities = $newEntities;
+        $this->unmodifiedEntities = $unmodifiedEntities;
     }
 
     /**
@@ -34,7 +41,16 @@ final class Collection
      */
     public static function of(string $name, Set $newEntities): self
     {
-        return new self($name, $newEntities);
+        return new self($name, $newEntities, Set::of());
+    }
+
+    public function with(self $unmodified): self
+    {
+        return new self(
+            $this->name,
+            $this->newEntities,
+            $unmodified->entities(),
+        );
     }
 
     /**
@@ -51,6 +67,22 @@ final class Collection
     public function newEntities(): Set
     {
         return $this->newEntities;
+    }
+
+    /**
+     * @return Set<Entity>
+     */
+    public function unmodifiedEntities(): Set
+    {
+        return $this->unmodifiedEntities;
+    }
+
+    /**
+     * @return Set<Entity>
+     */
+    public function entities(): Set
+    {
+        return $this->unmodifiedEntities->merge($this->newEntities);
     }
 
     public function referenceSame(self $collection): bool

--- a/src/Raw/Aggregate/Collection.php
+++ b/src/Raw/Aggregate/Collection.php
@@ -13,27 +13,27 @@ final class Collection
     /** @var non-empty-string */
     private string $name;
     /** @var Set<Set<Property>> */
-    private Set $properties;
+    private Set $entities;
 
     /**
      * @param non-empty-string $name
-     * @param Set<Set<Property>> $properties
+     * @param Set<Set<Property>> $entities
      */
-    private function __construct(string $name, Set $properties)
+    private function __construct(string $name, Set $entities)
     {
         $this->name = $name;
-        $this->properties = $properties;
+        $this->entities = $entities;
     }
 
     /**
      * @psalm-pure
      *
      * @param non-empty-string $name
-     * @param Set<Set<Property>> $properties
+     * @param Set<Set<Property>> $entities
      */
-    public static function of(string $name, Set $properties): self
+    public static function of(string $name, Set $entities): self
     {
-        return new self($name, $properties);
+        return new self($name, $entities);
     }
 
     /**
@@ -47,9 +47,9 @@ final class Collection
     /**
      * @return Set<Set<Property>>
      */
-    public function properties(): Set
+    public function entities(): Set
     {
-        return $this->properties;
+        return $this->entities;
     }
 
     public function referenceSame(self $collection): bool

--- a/src/Raw/Aggregate/Collection.php
+++ b/src/Raw/Aggregate/Collection.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Formal\ORM\Raw\Aggregate;
 
+use Formal\ORM\Raw\Aggregate\Collection\Entity;
 use Innmind\Immutable\Set;
 
 /**
@@ -12,12 +13,12 @@ final class Collection
 {
     /** @var non-empty-string */
     private string $name;
-    /** @var Set<Set<Property>> */
+    /** @var Set<Entity> */
     private Set $entities;
 
     /**
      * @param non-empty-string $name
-     * @param Set<Set<Property>> $entities
+     * @param Set<Entity> $entities
      */
     private function __construct(string $name, Set $entities)
     {
@@ -29,7 +30,7 @@ final class Collection
      * @psalm-pure
      *
      * @param non-empty-string $name
-     * @param Set<Set<Property>> $entities
+     * @param Set<Entity> $entities
      */
     public static function of(string $name, Set $entities): self
     {
@@ -45,7 +46,7 @@ final class Collection
     }
 
     /**
-     * @return Set<Set<Property>>
+     * @return Set<Entity>
      */
     public function entities(): Set
     {

--- a/src/Raw/Aggregate/Collection.php
+++ b/src/Raw/Aggregate/Collection.php
@@ -14,27 +14,27 @@ final class Collection
     /** @var non-empty-string */
     private string $name;
     /** @var Set<Entity> */
-    private Set $entities;
+    private Set $newEntities;
 
     /**
      * @param non-empty-string $name
-     * @param Set<Entity> $entities
+     * @param Set<Entity> $newEntities
      */
-    private function __construct(string $name, Set $entities)
+    private function __construct(string $name, Set $newEntities)
     {
         $this->name = $name;
-        $this->entities = $entities;
+        $this->newEntities = $newEntities;
     }
 
     /**
      * @psalm-pure
      *
      * @param non-empty-string $name
-     * @param Set<Entity> $entities
+     * @param Set<Entity> $newEntities
      */
-    public static function of(string $name, Set $entities): self
+    public static function of(string $name, Set $newEntities): self
     {
-        return new self($name, $entities);
+        return new self($name, $newEntities);
     }
 
     /**
@@ -48,9 +48,9 @@ final class Collection
     /**
      * @return Set<Entity>
      */
-    public function entities(): Set
+    public function newEntities(): Set
     {
-        return $this->entities;
+        return $this->newEntities;
     }
 
     public function referenceSame(self $collection): bool

--- a/src/Raw/Aggregate/Collection.php
+++ b/src/Raw/Aggregate/Collection.php
@@ -52,7 +52,7 @@ final class Collection
         return new self(
             $this->name,
             $this->newEntities,
-            $unmodified->entities(),
+            $unmodified->newEntities(),
         );
     }
 

--- a/src/Raw/Aggregate/Collection.php
+++ b/src/Raw/Aggregate/Collection.php
@@ -44,6 +44,9 @@ final class Collection
         return new self($name, $newEntities, Set::of());
     }
 
+    /**
+     * @internal
+     */
     public function with(self $unmodified): self
     {
         return new self(

--- a/src/Raw/Aggregate/Collection/Entity.php
+++ b/src/Raw/Aggregate/Collection/Entity.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace Formal\ORM\Raw\Aggregate\Collection;
 
-use Formal\ORM\Raw\Aggregate\Property;
+use Formal\ORM\Raw\Aggregate\{
+    Property,
+    Collection\Entity\Reference,
+};
 use Innmind\Immutable\Set;
 
 /**
@@ -11,14 +14,16 @@ use Innmind\Immutable\Set;
  */
 final class Entity
 {
+    private Reference $reference;
     /** @var Set<Property> */
     private Set $properties;
 
     /**
      * @param Set<Property> $properties
      */
-    private function __construct(Set $properties)
+    private function __construct(Reference $reference, Set $properties)
     {
+        $this->reference = $reference;
         $this->properties = $properties;
     }
 
@@ -27,9 +32,14 @@ final class Entity
      *
      * @param Set<Property> $properties
      */
-    public static function of(Set $properties): self
+    public static function of(Reference $reference, Set $properties): self
     {
-        return new self($properties);
+        return new self($reference, $properties);
+    }
+
+    public function reference(): Reference
+    {
+        return $this->reference;
     }
 
     /**

--- a/src/Raw/Aggregate/Collection/Entity.php
+++ b/src/Raw/Aggregate/Collection/Entity.php
@@ -37,6 +37,6 @@ final class Entity
      */
     public function properties(): Set
     {
-        return $this->properties();
+        return $this->properties;
     }
 }

--- a/src/Raw/Aggregate/Collection/Entity.php
+++ b/src/Raw/Aggregate/Collection/Entity.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Raw\Aggregate\Collection;
+
+use Formal\ORM\Raw\Aggregate\Property;
+use Innmind\Immutable\Set;
+
+/**
+ * @psalm-immutable
+ */
+final class Entity
+{
+    /** @var Set<Property> */
+    private Set $properties;
+
+    /**
+     * @param Set<Property> $properties
+     */
+    private function __construct(Set $properties)
+    {
+        $this->properties = $properties;
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param Set<Property> $properties
+     */
+    public static function of(Set $properties): self
+    {
+        return new self($properties);
+    }
+
+    /**
+     * @return Set<Property>
+     */
+    public function properties(): Set
+    {
+        return $this->properties();
+    }
+}

--- a/src/Raw/Aggregate/Collection/Entity/Reference.php
+++ b/src/Raw/Aggregate/Collection/Entity/Reference.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Raw\Aggregate\Collection\Entity;
+
+use Ramsey\Uuid\{
+    UuidInterface,
+    Uuid,
+};
+
+/**
+ * @psalm-immutable
+ */
+final class Reference
+{
+    private UuidInterface $id;
+
+    private function __construct(UuidInterface $id)
+    {
+        $this->id = $id;
+    }
+
+    public static function new(): self
+    {
+        return new self(Uuid::uuid4());
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function of(string $string): self
+    {
+        return new self(Uuid::fromString($string));
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function toString(): string
+    {
+        return $this->id->toString();
+    }
+}

--- a/src/Raw/Aggregate/Entity.php
+++ b/src/Raw/Aggregate/Entity.php
@@ -3,10 +3,7 @@ declare(strict_types = 1);
 
 namespace Formal\ORM\Raw\Aggregate;
 
-use Innmind\Immutable\{
-    Set,
-    Maybe,
-};
+use Innmind\Immutable\Set;
 
 /**
  * @psalm-immutable

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -134,7 +134,6 @@ final class Repository
 
         $this->loaded->add($this, $now);
 
-        /** @psalm-suppress InvalidArgument For some reason Psalm lose track of $then type */
         $_ = $then->match(
             fn($then) => $this->adapter->update(
                 ($this->diff)($then, $now),

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -15,6 +15,7 @@ use Formal\ORM\{
     Repository\Sort,
     Specification\Normalize as NormalizeSpecification,
 };
+use Formal\ORM\Repository\KnownCollectionEntity;
 use Innmind\Specification\Specification;
 use Innmind\Immutable\Maybe;
 
@@ -57,16 +58,17 @@ final class Repository
         Aggregate $definition,
         \Closure $inTransaction,
     ) {
+        $knownCollectionEntity = KnownCollectionEntity::new();
         $this->adapter = $adapter;
         $this->id = $definition->id();
         $this->inTransaction = $inTransaction;
         $this->normalizeSpecification = NormalizeSpecification::of($definition);
         $this->loaded = Loaded::of($repositories, $definition);
-        $this->normalize = Normalize::of($definition);
-        $this->denormalize = Denormalize::of($definition);
+        $this->normalize = Normalize::of($definition, $knownCollectionEntity);
+        $this->denormalize = Denormalize::of($definition, $knownCollectionEntity);
         $this->instanciate = Instanciate::of($definition);
         $this->extract = Extract::of($definition);
-        $this->diff = Diff::of($definition);
+        $this->diff = Diff::of($definition, $knownCollectionEntity);
         $this->sort = Sort::of($definition);
     }
 

--- a/src/Repository/Denormalize.php
+++ b/src/Repository/Denormalize.php
@@ -40,8 +40,10 @@ final class Denormalize
     /**
      * @param Definition<T> $definition
      */
-    private function __construct(Definition $definition)
-    {
+    private function __construct(
+        Definition $definition,
+        KnownCollectionEntity $knownCollectionEntity,
+    ) {
         $this->definition = $definition;
         $this->instanciate = new Instanciate;
         /** @var \Closure(Aggregate\Id): Id<T> */
@@ -76,6 +78,7 @@ final class Denormalize
                 ->map(fn($collection) => [$collection->name(), Denormalize\Collection::of(
                     $collection,
                     $this->instanciate,
+                    $knownCollectionEntity,
                 )])
                 ->toList(),
         );
@@ -107,9 +110,11 @@ final class Denormalize
      *
      * @return self<A>
      */
-    public static function of(Definition $definition): self
-    {
-        return new self($definition);
+    public static function of(
+        Definition $definition,
+        KnownCollectionEntity $knownCollectionEntity,
+    ): self {
+        return new self($definition, $knownCollectionEntity);
     }
 
     /**
@@ -160,7 +165,7 @@ final class Denormalize
                     fn($collection) => $this
                         ->collections
                         ->get($collection->name())
-                        ->map(static fn($denormalize): Set => $denormalize($collection))
+                        ->map(static fn($denormalize): Set => $denormalize($data->id(), $collection))
                         ->map(static fn($value) => [$collection->name(), $value])
                         ->toSequence()
                         ->toSet(),

--- a/src/Repository/Denormalize/Collection.php
+++ b/src/Repository/Denormalize/Collection.php
@@ -53,6 +53,7 @@ final class Collection
             ->map(function($entity) use ($class) {
                 $entity = Map::of(
                     ...$entity
+                        ->properties()
                         ->flatMap(
                             fn($property) => $this
                                 ->properties

--- a/src/Repository/Denormalize/Collection.php
+++ b/src/Repository/Denormalize/Collection.php
@@ -10,7 +10,6 @@ use Formal\ORM\{
     Raw\Aggregate\Collection as Raw,
     Repository\KnownCollectionEntity,
 };
-use Formal\ORM\Raw\Aggregate\Collection\Entity\Reference;
 use Innmind\Reflection\Instanciate;
 use Innmind\Immutable\{
     Map,
@@ -59,6 +58,7 @@ final class Collection
         return $collection
             ->entities()
             ->map(function($entity) use ($class, $id, $collection) {
+                $reference = $entity->reference();
                 $entity = Map::of(
                     ...$entity
                         ->properties()
@@ -76,14 +76,14 @@ final class Collection
 
                 /** @var T */
                 return ($this->instanciate)($class, $entity)
-                    ->map(fn($entity) => $this->knownCollectionEntity->add(
+                    ->map(fn($object) => $this->knownCollectionEntity->add(
                         $id,
                         $collection->name(),
-                        $entity,
-                        Reference::new(), // TODO get the reference stored by the adapter
+                        $object,
+                        $reference,
                     ))
                     ->match(
-                        static fn($entity) => $entity,
+                        static fn($object) => $object,
                         static fn() => throw new \RuntimeException("Unable to denormalize collection of type '$class'"),
                     );
             });

--- a/src/Repository/Denormalize/Collection.php
+++ b/src/Repository/Denormalize/Collection.php
@@ -56,7 +56,7 @@ final class Collection
         $class = $this->definition->class();
 
         return $collection
-            ->entities()
+            ->newEntities()
             ->map(function($entity) use ($class, $id, $collection) {
                 $reference = $entity->reference();
                 $entity = Map::of(

--- a/src/Repository/Denormalize/Collection.php
+++ b/src/Repository/Denormalize/Collection.php
@@ -6,9 +6,9 @@ namespace Formal\ORM\Repository\Denormalize;
 use Formal\ORM\{
     Definition\Aggregate\Collection as Definition,
     Definition\Aggregate\Property,
-    Raw\Aggregate\Id,
     Raw\Aggregate\Collection as Raw,
     Repository\KnownCollectionEntity,
+    Id,
 };
 use Innmind\Reflection\Instanciate;
 use Innmind\Immutable\{

--- a/src/Repository/Denormalize/Collection.php
+++ b/src/Repository/Denormalize/Collection.php
@@ -49,10 +49,10 @@ final class Collection
         $class = $this->definition->class();
 
         return $collection
-            ->properties()
-            ->map(function($properties) use ($class) {
-                $properties = Map::of(
-                    ...$properties
+            ->entities()
+            ->map(function($entity) use ($class) {
+                $entity = Map::of(
+                    ...$entity
                         ->flatMap(
                             fn($property) => $this
                                 ->properties
@@ -66,7 +66,7 @@ final class Collection
                 );
 
                 /** @var T */
-                return ($this->instanciate)($class, $properties)->match(
+                return ($this->instanciate)($class, $entity)->match(
                     static fn($collection) => $collection,
                     static fn() => throw new \RuntimeException("Unable to denormalize collection of type '$class'"),
                 );

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -36,8 +36,6 @@ final class Diff
     private Map $normalizeOptional;
     /** @var Map<non-empty-string, Normalize\Collection> */
     private Map $normalizeCollection;
-    /** @var \Closure(T): Raw\Aggregate\Id */
-    private \Closure $extractId;
 
     /**
      * @param Definition<T> $definition
@@ -92,11 +90,6 @@ final class Diff
                 ->toList(),
         );
         $id = $definition->id();
-        /**
-         * @psalm-suppress InvalidArgument
-         * @var \Closure(T): Raw\Aggregate\Id
-         */
-        $this->extractId = static fn(object $aggregate): Raw\Aggregate\Id => $id->normalize($id->extract($aggregate));
     }
 
     /**

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -69,7 +69,6 @@ final class Diff
                 )])
                 ->toList(),
         );
-        $id = $definition->id();
     }
 
     /**

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -246,6 +246,11 @@ final class Diff
         Set $then,
         Set $now,
     ): Raw\Aggregate\Collection {
+        // We memoize to make sure we won't iterate multiple times over a
+        // lazy Set leading to unwanted amount of persisted entities.
+        $then = $then->memoize();
+        $now = $now->memoize();
+
         $diff = $now->partition(static fn($entity) => $then->contains($entity));
         /** @var Set<object> */
         $unmodified = $diff

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -28,8 +28,6 @@ final class Diff
     /** @var Definition<T> */
     private Definition $definition;
     private Extract $extract;
-    /** @var Set<non-empty-string> */
-    private Set $properties;
     /** @var Map<non-empty-string, Normalize\Entity> */
     private Map $normalizeEntity;
     /** @var Map<non-empty-string, Normalize\Optional> */
@@ -44,24 +42,6 @@ final class Diff
     {
         $this->definition = $definition;
         $this->extract = new Extract;
-        $this->properties = $definition
-            ->properties()
-            ->map(static fn($property) => $property->name())
-            ->merge(
-                $definition
-                    ->entities()
-                    ->map(static fn($entity) => $entity->name()),
-            )
-            ->merge(
-                $definition
-                    ->optionals()
-                    ->map(static fn($optional) => $optional->name()),
-            )
-            ->merge(
-                $definition
-                    ->collections()
-                    ->map(static fn($collection) => $collection->name()),
-            );
         $this->normalizeEntity = Map::of(
             ...$definition
                 ->entities()

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -6,6 +6,7 @@ namespace Formal\ORM\Repository;
 use Formal\ORM\{
     Definition\Aggregate as Definition,
     Raw,
+    Id,
 };
 use Innmind\Reflection\Extract;
 use Innmind\Immutable\{
@@ -80,7 +81,8 @@ final class Diff
      */
     public function __invoke(Denormalized $then, Denormalized $now): Raw\Diff
     {
-        $id = $this->definition->id()->normalize($now->id());
+        $id = $now->id();
+        $normalizedId = $this->definition->id()->normalize($now->id());
         $then = $then->properties();
         $now = $now->properties();
 
@@ -175,7 +177,7 @@ final class Diff
             ->toSet();
 
         return Raw\Diff::of(
-            $id,
+            $normalizedId,
             $properties,
             $entities,
             $optionals,
@@ -240,7 +242,7 @@ final class Diff
 
     private static function diffCollections(
         Normalize\Collection $normalize,
-        Raw\Aggregate\Id $id,
+        Id $id,
         Set $then,
         Set $now,
     ): Raw\Aggregate\Collection {

--- a/src/Repository/KnownCollectionEntity.php
+++ b/src/Repository/KnownCollectionEntity.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Repository;
+
+use Formal\ORM\Raw\Aggregate\{
+    Id,
+    Collection\Entity\Reference,
+};
+use Innmind\Immutable\Map;
+
+final class KnownCollectionEntity
+{
+    /** @var \WeakMap<Id, Map<non-empty-string, \WeakMap<object, Reference>>> */
+    private \WeakMap $aggregates;
+
+    private function __construct()
+    {
+        /** @var \WeakMap<Id, Map<non-empty-string, \WeakMap<object, Reference>>> */
+        $this->aggregates = new \WeakMap;
+    }
+
+    public static function new(): self
+    {
+        return new self;
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param T $entity
+     * @param non-empty-string $collection
+     *
+     * @return T
+     */
+    public function add(
+        Id $id,
+        string $collection,
+        object $entity,
+        Reference $reference,
+    ): object {
+        /** @var Map<non-empty-string, \WeakMap<object, Reference>> */
+        $aggregate = $this->aggregates[$id] ?? Map::of();
+        $entities = $aggregate->get($collection)->match(
+            static fn($entities) => $entities,
+            static fn() => new \WeakMap,
+        );
+        $entities[$entity] = $reference;
+
+        return $entity;
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param T $entity
+     * @param non-empty-string $collection
+     */
+    public function reference(
+        Id $id,
+        string $collection,
+        object $entity,
+    ): Reference {
+        /** @var Map<non-empty-string, \WeakMap<object, Reference>> */
+        $aggregate = $this->aggregates[$id] ?? Map::of();
+        /** @var \WeakMap<object, Reference> */
+        $entities = $aggregate->get($collection)->match(
+            static fn($entities) => $entities,
+            static fn() => new \WeakMap,
+        );
+        $reference = $entities[$entity] ?? Reference::new();
+        $entities[$entity] = $reference;
+
+        return $reference;
+    }
+}

--- a/src/Repository/KnownCollectionEntity.php
+++ b/src/Repository/KnownCollectionEntity.php
@@ -28,17 +28,27 @@ final class KnownCollectionEntity
     /**
      * @template T of object
      *
+     * @param \WeakReference<Id> $idReference
      * @param T $entity
      * @param non-empty-string $collection
      *
      * @return T
      */
     public function add(
-        Id $id,
+        \WeakReference $idReference,
         string $collection,
         object $entity,
         Reference $reference,
     ): object {
+        $id = $idReference->get();
+
+        if (\is_null($id)) {
+            // The aggregate can go out of memory in case the user throw out
+            // the aggregate from memory but keep the collection.
+            // In this case we can't keep track of the reference.
+            return $entity;
+        }
+
         /** @var Map<non-empty-string, \WeakMap<object, Reference>> */
         $aggregate = $this->aggregates[$id] ?? Map::of();
         /** @var \WeakMap<object, Reference> */

--- a/src/Repository/KnownCollectionEntity.php
+++ b/src/Repository/KnownCollectionEntity.php
@@ -3,9 +3,9 @@ declare(strict_types = 1);
 
 namespace Formal\ORM\Repository;
 
-use Formal\ORM\Raw\Aggregate\{
+use Formal\ORM\{
     Id,
-    Collection\Entity\Reference,
+    Raw\Aggregate\Collection\Entity\Reference,
 };
 use Innmind\Immutable\Map;
 
@@ -41,11 +41,14 @@ final class KnownCollectionEntity
     ): object {
         /** @var Map<non-empty-string, \WeakMap<object, Reference>> */
         $aggregate = $this->aggregates[$id] ?? Map::of();
+        /** @var \WeakMap<object, Reference> */
         $entities = $aggregate->get($collection)->match(
             static fn($entities) => $entities,
             static fn() => new \WeakMap,
         );
         $entities[$entity] = $reference;
+        $aggregate = ($aggregate)($collection, $entities);
+        $this->aggregates[$id] = $aggregate;
 
         return $entity;
     }
@@ -70,6 +73,8 @@ final class KnownCollectionEntity
         );
         $reference = $entities[$entity] ?? Reference::new();
         $entities[$entity] = $reference;
+        $aggregate = ($aggregate)($collection, $entities);
+        $this->aggregates[$id] = $aggregate;
 
         return $reference;
     }

--- a/src/Repository/Normalize.php
+++ b/src/Repository/Normalize.php
@@ -74,11 +74,10 @@ final class Normalize
     public function __invoke(Denormalized $denormalized): Aggregate
     {
         $properties = $denormalized->properties();
-        $id = $this->definition->id()->normalize($denormalized->id());
 
         /** @psalm-suppress MixedArgument Due to the collection normalization */
         return Aggregate::of(
-            $id,
+            $this->definition->id()->normalize($denormalized->id()),
             $this
                 ->definition
                 ->properties()
@@ -132,7 +131,7 @@ final class Normalize
                         ->flatMap(
                             static fn($normalize) => $properties
                                 ->get($collection->name())
-                                ->map(static fn($object) => $normalize($id, $object)),
+                                ->map(static fn($object) => $normalize($denormalized->id(), $object)),
                         )
                         ->toSequence()
                         ->toSet(),

--- a/src/Repository/Normalize/Collection.php
+++ b/src/Repository/Normalize/Collection.php
@@ -9,10 +9,7 @@ use Formal\ORM\{
     Raw\Aggregate\Property,
 };
 use Innmind\Reflection\Extract;
-use Innmind\Immutable\{
-    Set,
-    Maybe,
-};
+use Innmind\Immutable\Set;
 
 /**
  * @internal

--- a/src/Repository/Normalize/Collection.php
+++ b/src/Repository/Normalize/Collection.php
@@ -41,30 +41,32 @@ final class Collection
     public function __invoke(Set $collection): Raw
     {
         $class = $this->definition->class();
-        $properties = $collection->map(
+        $entities = $collection->map(
             fn($object) => ($this->extract)($object, $this->properties)->match(
-                static fn($properties) => $properties,
+                static fn($entities) => $entities,
                 static fn() => throw new \LogicException("Failed to extract properties from '$class'"),
             ),
         );
 
         return Raw::of(
             $this->definition->name(),
-            $properties->map(
-                fn($properties) => $this
-                    ->definition
-                    ->properties()
-                    ->flatMap(
-                        static fn($property) => $properties
-                            ->get($property->name())
-                            ->map(static fn($value) => Property::of(
-                                $property->name(),
-                                $property->type()->normalize($value),
-                            ))
-                            ->toSequence()
-                            ->toSet(),
-                    ),
-            ),
+            $entities
+                ->map(
+                    fn($entity) => $this
+                        ->definition
+                        ->properties()
+                        ->flatMap(
+                            static fn($property) => $entity
+                                ->get($property->name())
+                                ->map(static fn($value) => Property::of(
+                                    $property->name(),
+                                    $property->type()->normalize($value),
+                                ))
+                                ->toSequence()
+                                ->toSet(),
+                        ),
+                )
+                ->map(Raw\Entity::of(...)),
         );
     }
 

--- a/src/Repository/Normalize/Collection.php
+++ b/src/Repository/Normalize/Collection.php
@@ -7,8 +7,8 @@ use Formal\ORM\{
     Definition\Aggregate\Collection as Definition,
     Raw\Aggregate\Collection as Raw,
     Raw\Aggregate\Property,
-    Raw\Aggregate\Id,
     Repository\KnownCollectionEntity,
+    Id,
 };
 use Innmind\Reflection\Extract;
 use Innmind\Immutable\{

--- a/src/Repository/Normalize/Collection.php
+++ b/src/Repository/Normalize/Collection.php
@@ -88,8 +88,8 @@ final class Collection
                                 ->toSet(),
                         ),
                 )
+                ->map(Raw\Entity::of(...))
                 ->values()
-                ->map(Raw\Entity::of(...)) // TODO inject the reference
                 ->toSet(),
         );
     }


### PR DESCRIPTION
## Request

Closes #3 

## Implementation

Contrary to what's proposed in the issue, it's not necessary to use a trait in the entities. The ORM can keep track of the reference of an entity on its own.

When an entity is modified (meaning a new instance is created) the original instance is removed from memory and its reference disappear, allowing the ORM to remove any value that is no longer present in memory.