### PR TITLE
Allow users to use an id property in their entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - (Optional) Entities id column with the `SQL` adapter now use the Aggregate id as a value, the columns in the Aggregate column referencing these columns have been removed
 - `Formal\ORM\Raw\Aggregate\Collection::properties()` has been renamed `::entities()`
 - Collection tables now have an `entityReference` column
+- Collection, entities and optional entities table column `id` has been renamed `aggregateId`
 
 ## 1.2.0 - 2024-01-15
 

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -31,13 +31,13 @@ return static function() {
                     CREATE TABLE  `user` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `createdAt` varchar(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_mainAddress` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`id`))
+                    CREATE TABLE  `user_mainAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_billingAddress` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`id`))
+                    CREATE TABLE  `user_billingAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_addresses` (`entityReference` varchar(36) NOT NULL  COMMENT 'UUID', `id` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`entityReference`), CONSTRAINT `FK_user_addresses` FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    CREATE TABLE  `user_addresses` (`entityReference` varchar(36) NOT NULL  COMMENT 'UUID', `aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`entityReference`), CONSTRAINT `FK_user_addresses` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
                     SQL,
                 ])
                 ->same($queries);

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -56,7 +56,7 @@ final class CollectionTable
                     ->in($this->name)
                     ->as($definition->name().'_'.$property->name()),
             );
-        $this->id = Column\Name::of('id')->in($this->name);
+        $this->id = Column\Name::of('aggregateId')->in($this->name);
         $this->reference = Column\Name::of('entityReference')->in($this->name);
         $this->select = Select::from($this->name)->columns(
             $this->id,
@@ -92,7 +92,7 @@ final class CollectionTable
     public function foreignKey(): Table\Column
     {
         return Table\Column::of(
-            Table\Column\Name::of('id'),
+            Table\Column\Name::of('aggregateId'),
             Table\Column\Type::varchar(36)->comment('UUID'),
         );
     }
@@ -161,7 +161,7 @@ final class CollectionTable
                         ->map(
                             static fn($entity) => new Row(
                                 new Row\Value(
-                                    Column\Name::of('id')->in($table),
+                                    Column\Name::of('aggregateId')->in($table),
                                     $id->value(),
                                 ),
                                 new Row\Value(

--- a/src/Adapter/SQL/EntityTable.php
+++ b/src/Adapter/SQL/EntityTable.php
@@ -71,7 +71,7 @@ final class EntityTable
     public function primaryKey(): Table\Column
     {
         return Table\Column::of(
-            Table\Column\Name::of('id'),
+            Table\Column\Name::of('aggregateId'),
             Table\Column\Type::varchar(36)->comment('UUID'),
         );
     }
@@ -116,7 +116,7 @@ final class EntityTable
             $table,
             new Row(
                 new Row\Value(
-                    Column\Name::of('id')->in($table),
+                    Column\Name::of('aggregateId')->in($table),
                     $id->value(),
                 ),
                 ...$properties
@@ -152,7 +152,7 @@ final class EntityTable
                             ->toList(),
                     ),
                 )->where(Specification\Property::of(
-                    'id',
+                    'aggregateId',
                     Sign::equality,
                     $id->value(),
                 )),

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -95,7 +95,7 @@ final class MainTable
             fn(Select $select, $_, $table) => $select->join(
                 Join::left($table->name())->on(
                     Column\Name::of($this->definition->id()->property())->in($this->name),
-                    Column\Name::of('id')->in($table->name()),
+                    $table->primaryKey()->name()->in($table->name()),
                 ),
             ),
         );
@@ -129,7 +129,7 @@ final class MainTable
             fn(Select $select, $_, $table) => $select->join(
                 Join::left($table->name())->on(
                     Column\Name::of($this->definition->id()->property())->in($this->name),
-                    Column\Name::of('id')->in($table->name()),
+                    $table->primaryKey()->name()->in($table->name()),
                 ),
             ),
         );

--- a/src/Adapter/SQL/OptionalTable.php
+++ b/src/Adapter/SQL/OptionalTable.php
@@ -55,7 +55,7 @@ final class OptionalTable
                     ->as($definition->name().'_'.$property->name()),
             );
         $this->select = Select::onDemand($this->name)->columns(
-            Column\Name::of('id')->in($this->name),
+            Column\Name::of('aggregateId')->in($this->name),
             ...$this->columns->toList(),
         );
     }
@@ -79,7 +79,7 @@ final class OptionalTable
     public function primaryKey(): Table\Column
     {
         return Table\Column::of(
-            Table\Column\Name::of('id'),
+            Table\Column\Name::of('aggregateId'),
             Table\Column\Type::varchar(36)->comment('UUID'),
         );
     }
@@ -117,7 +117,7 @@ final class OptionalTable
     public function select(Id $id): Select
     {
         return $this->select->where(PropertySpecification::of(
-            'id',
+            'aggregateId',
             Sign::equality,
             $id->value(),
         ));
@@ -136,7 +136,7 @@ final class OptionalTable
             $table,
             new Row(
                 new Row\Value(
-                    Column\Name::of('id')->in($table),
+                    Column\Name::of('aggregateId')->in($table),
                     $id->value(),
                 ),
                 ...$properties
@@ -183,14 +183,14 @@ final class OptionalTable
                     ),
                 )
                     ->where(PropertySpecification::of(
-                        'id',
+                        'aggregateId',
                         Sign::equality,
                         $id->value(),
                     )),
             ),
             fn() => Sequence::of(
                 Delete::from($this->name)->where(PropertySpecification::of(
-                    'id',
+                    'aggregateId',
                     Sign::equality,
                     $id->value(),
                 )),


### PR DESCRIPTION
## Problem

The SQL adapter uses a column `id` for entities, optional entities and collections to reference the parent aggregate id. This name prevents users to have a property named `id` in their entities.

## Solution

Rename `id` to `aggregateId`. Users should not reference the concept of an aggregate in their entities, thus reducing the probability of collisions.