### PR TITLE
Use sequences instead of sets

### DIFF
--- a/src/Adapter/Filesystem/Decode.php
+++ b/src/Adapter/Filesystem/Decode.php
@@ -17,6 +17,7 @@ use Innmind\Json\Json;
 use Innmind\Immutable\{
     Maybe,
     Set,
+    Sequence,
     Predicate\Instance,
 };
 
@@ -67,8 +68,7 @@ final class Decode
                         ->map(static fn($file) => Aggregate\Property::of(
                             $file->name()->toString(),
                             Json::decode($file->content()->toString()),
-                        ))
-                        ->toSet(),
+                        )),
                 ),
             $directory
                 ->get(Name::of('entities'))
@@ -89,8 +89,7 @@ final class Decode
                                     ))
                                     ->toSet(),
                             ),
-                        )
-                        ->toSet(),
+                        ),
                 ),
             $directory
                 ->get(Name::of('optionals'))
@@ -116,8 +115,7 @@ final class Decode
                                             ->toSet(),
                                     ),
                             ),
-                        )
-                        ->toSet(),
+                        ),
                 ),
             $directory
                 ->get(Name::of('collections'))
@@ -141,10 +139,9 @@ final class Decode
                                     ),
                                 ),
                             ),
-                        )
-                        ->toSet(),
+                        ),
                 ),
-        )->map(static fn(Set $properties, Set $entities, Set $optionals, Set $collections) => Aggregate::of(
+        )->map(static fn(Sequence $properties, Sequence $entities, Sequence $optionals, Sequence $collections) => Aggregate::of(
             $id($directory),
             $properties,
             $entities,

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -77,8 +77,7 @@ final class Decode
                 ->map(static fn($value) => Aggregate\Property::of(
                     Str::of($value->column()->toString())->drop(7)->toString(),
                     $value->value(),
-                ))
-                ->toSet(),
+                )),
             $this
                 ->mainTable
                 ->entities()

--- a/src/Adapter/SQL/Encode.php
+++ b/src/Adapter/SQL/Encode.php
@@ -47,12 +47,10 @@ final class Encode
         $optionals = $this->optionals($data);
         $collections = $this->collections($data);
 
-        return Sequence::of(
-            $main,
-            ...$entities->toList(),
-            ...$optionals->toList(),
-            ...$collections->toList(),
-        );
+        return Sequence::of($main)
+            ->append($entities)
+            ->append($optionals)
+            ->append($collections);
     }
 
     /**
@@ -73,9 +71,9 @@ final class Encode
     }
 
     /**
-     * @return Set<Query>
+     * @return Sequence<Query>
      */
-    private function entities(Aggregate $data): Set
+    private function entities(Aggregate $data): Sequence
     {
         return $data
             ->entities()
@@ -86,15 +84,14 @@ final class Encode
                     ->map(
                         static fn($table) => $table->insert($data->id(), $entity->properties()),
                     )
-                    ->toSequence()
-                    ->toSet(),
+                    ->toSequence(),
             );
     }
 
     /**
-     * @return Set<Query>
+     * @return Sequence<Query>
      */
-    private function optionals(Aggregate $data): Set
+    private function optionals(Aggregate $data): Sequence
     {
         return $data
             ->optionals()
@@ -107,8 +104,7 @@ final class Encode
                             static fn($properties) => $table->insert($data->id(), $properties),
                         ),
                     )
-                    ->toSequence()
-                    ->toSet(),
+                    ->toSequence(),
             );
     }
 
@@ -121,9 +117,9 @@ final class Encode
     }
 
     /**
-     * @return Set<Query>
+     * @return Sequence<Query>
      */
-    private function collections(Aggregate $data): Set
+    private function collections(Aggregate $data): Sequence
     {
         return $data
             ->collections()
@@ -137,8 +133,7 @@ final class Encode
                             $collection->entities(),
                         ),
                     )
-                    ->toSequence()
-                    ->toSet(),
+                    ->toSequence(),
             );
     }
 }

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -34,6 +34,7 @@ use Innmind\Immutable\{
     Map,
     Maybe,
     Set,
+    Sequence,
 };
 
 /**
@@ -161,9 +162,9 @@ final class MainTable
     }
 
     /**
-     * @return Set<Column>
+     * @return Sequence<Column>
      */
-    public function columnsDefinition(MapType $mapType): Set
+    public function columnsDefinition(MapType $mapType): Sequence
     {
         return $this
             ->definition
@@ -212,11 +213,11 @@ final class MainTable
     /**
      * @internal
      *
-     * @param Set<Aggregate\Property> $properties
+     * @param Sequence<Aggregate\Property> $properties
      */
     public function insert(
         Id $id,
-        Set $properties,
+        Sequence $properties,
     ): Query {
         $table = $this->name->name();
 
@@ -276,11 +277,11 @@ final class MainTable
     }
 
     /**
-     * @return Set<EntityTable>
+     * @return Sequence<EntityTable>
      */
-    public function entities(): Set
+    public function entities(): Sequence
     {
-        return $this->entities->values()->toSet();
+        return $this->entities->values();
     }
 
     /**
@@ -294,11 +295,11 @@ final class MainTable
     }
 
     /**
-     * @return Set<OptionalTable>
+     * @return Sequence<OptionalTable>
      */
-    public function optionals(): Set
+    public function optionals(): Sequence
     {
-        return $this->optionals->values()->toSet();
+        return $this->optionals->values();
     }
 
     /**
@@ -312,11 +313,11 @@ final class MainTable
     }
 
     /**
-     * @return Set<CollectionTable>
+     * @return Sequence<CollectionTable>
      */
-    public function collections(): Set
+    public function collections(): Sequence
     {
-        return $this->collections->values()->toSet();
+        return $this->collections->values();
     }
 
     /**

--- a/src/Adapter/SQL/Update.php
+++ b/src/Adapter/SQL/Update.php
@@ -45,8 +45,7 @@ final class Update
                             )
                             ->toSequence(),
                     )
-                    ->toSequence()
-                    ->toSet(),
+                    ->toSequence(),
             );
         $optionals = $data
             ->optionals()
@@ -58,8 +57,7 @@ final class Update
                         $data->id(),
                         $optional,
                     ))
-                    ->toSequence()
-                    ->toSet(),
+                    ->toSequence(),
             );
         $collections = $data
             ->collections()
@@ -74,16 +72,14 @@ final class Update
                             static fn($entity) => $entity->reference(),
                         ),
                     ))
-                    ->toSequence()
-                    ->toSet(),
+                    ->toSequence(),
             );
 
-        return Sequence::of(
-            $main,
-            ...$entities->toList(),
-            ...$optionals->toList(),
-            ...$collections->toList(),
-        )->flatMap(static fn($queries) => $queries);
+        return Sequence::of($main)
+            ->append($entities)
+            ->append($optionals)
+            ->append($collections)
+            ->flatMap(static fn($queries) => $queries);
     }
 
     /**

--- a/src/Definition/Aggregate.php
+++ b/src/Definition/Aggregate.php
@@ -7,7 +7,7 @@ use Formal\ORM\Definition\Aggregate\Parsing;
 use Innmind\Reflection\ReflectionClass;
 use Innmind\Immutable\{
     Str,
-    Set,
+    Sequence,
     Monoid\Concat,
 };
 
@@ -21,30 +21,30 @@ final class Aggregate
     private string $class;
     /** @var Aggregate\Identity<T> */
     private Aggregate\Identity $id;
-    /** @var Set<Aggregate\Property<T, mixed>> */
-    private Set $properties;
-    /** @var Set<Aggregate\Entity> */
-    private Set $entities;
-    /** @var Set<Aggregate\Optional> */
-    private Set $optionals;
-    /** @var Set<Aggregate\Collection> */
-    private Set $collections;
+    /** @var Sequence<Aggregate\Property<T, mixed>> */
+    private Sequence $properties;
+    /** @var Sequence<Aggregate\Entity> */
+    private Sequence $entities;
+    /** @var Sequence<Aggregate\Optional> */
+    private Sequence $optionals;
+    /** @var Sequence<Aggregate\Collection> */
+    private Sequence $collections;
 
     /**
      * @param class-string<T> $class
      * @param Aggregate\Identity<T> $id
-     * @param Set<Aggregate\Property<T, mixed>> $properties
-     * @param Set<Aggregate\Entity> $entities
-     * @param Set<Aggregate\Optional> $optionals
-     * @param Set<Aggregate\Collection> $collections
+     * @param Sequence<Aggregate\Property<T, mixed>> $properties
+     * @param Sequence<Aggregate\Entity> $entities
+     * @param Sequence<Aggregate\Optional> $optionals
+     * @param Sequence<Aggregate\Collection> $collections
      */
     private function __construct(
         string $class,
         Aggregate\Identity $id,
-        Set $properties,
-        Set $entities,
-        Set $optionals,
-        Set $collections,
+        Sequence $properties,
+        Sequence $entities,
+        Sequence $optionals,
+        Sequence $collections,
     ) {
         $this->class = $class;
         $this->id = $id;
@@ -116,33 +116,33 @@ final class Aggregate
     }
 
     /**
-     * @return Set<Aggregate\Property<T, mixed>>
+     * @return Sequence<Aggregate\Property<T, mixed>>
      */
-    public function properties(): Set
+    public function properties(): Sequence
     {
         return $this->properties;
     }
 
     /**
-     * @return Set<Aggregate\Entity>
+     * @return Sequence<Aggregate\Entity>
      */
-    public function entities(): Set
+    public function entities(): Sequence
     {
         return $this->entities;
     }
 
     /**
-     * @return Set<Aggregate\Optional>
+     * @return Sequence<Aggregate\Optional>
      */
-    public function optionals(): Set
+    public function optionals(): Sequence
     {
         return $this->optionals;
     }
 
     /**
-     * @return Set<Aggregate\Collection>
+     * @return Sequence<Aggregate\Collection>
      */
-    public function collections(): Set
+    public function collections(): Sequence
     {
         return $this->collections;
     }

--- a/src/Definition/Aggregate/Parsing.php
+++ b/src/Definition/Aggregate/Parsing.php
@@ -16,6 +16,7 @@ use Innmind\Type\ClassName;
 use Innmind\Immutable\{
     Maybe,
     Set,
+    Sequence,
     Predicate\Instance,
 };
 
@@ -29,30 +30,30 @@ final class Parsing
     private string $class;
     /** @var Maybe<Identity<T>> */
     private Maybe $id;
-    /** @var Set<Property<T, mixed>> */
-    private Set $properties;
-    /** @var Set<Entity> */
-    private Set $entities;
-    /** @var Set<Optional> */
-    private Set $optionals;
-    /** @var Set<Collection> */
-    private Set $collections;
+    /** @var Sequence<Property<T, mixed>> */
+    private Sequence $properties;
+    /** @var Sequence<Entity> */
+    private Sequence $entities;
+    /** @var Sequence<Optional> */
+    private Sequence $optionals;
+    /** @var Sequence<Collection> */
+    private Sequence $collections;
 
     /**
      * @param class-string<T> $class
      * @param Maybe<Identity<T>> $id
-     * @param Set<Property<T, mixed>> $properties
-     * @param Set<Entity> $entities
-     * @param Set<Optional> $optionals
-     * @param Set<Collection> $collections
+     * @param Sequence<Property<T, mixed>> $properties
+     * @param Sequence<Entity> $entities
+     * @param Sequence<Optional> $optionals
+     * @param Sequence<Collection> $collections
      */
     private function __construct(
         string $class,
         Maybe $id,
-        Set $properties,
-        Set $entities,
-        Set $optionals,
-        Set $collections,
+        Sequence $properties,
+        Sequence $entities,
+        Sequence $optionals,
+        Sequence $collections,
     ) {
         $this->class = $class;
         $this->id = $id;
@@ -75,7 +76,7 @@ final class Parsing
         /** @var Maybe<Identity<A>> */
         $id = Maybe::nothing();
 
-        return new self($class, $id, Set::of(), Set::of(), Set::of(), Set::of());
+        return new self($class, $id, Sequence::of(), Sequence::of(), Sequence::of(), Sequence::of());
     }
 
     /**
@@ -143,33 +144,33 @@ final class Parsing
     }
 
     /**
-     * @return Set<Property<T, mixed>>
+     * @return Sequence<Property<T, mixed>>
      */
-    public function properties(): Set
+    public function properties(): Sequence
     {
         return $this->properties;
     }
 
     /**
-     * @return Set<Entity>
+     * @return Sequence<Entity>
      */
-    public function entities(): Set
+    public function entities(): Sequence
     {
         return $this->entities;
     }
 
     /**
-     * @return Set<Optional>
+     * @return Sequence<Optional>
      */
-    public function optionals(): Set
+    public function optionals(): Sequence
     {
         return $this->optionals;
     }
 
     /**
-     * @return Set<Collection>
+     * @return Sequence<Collection>
      */
-    public function collections(): Set
+    public function collections(): Sequence
     {
         return $this->collections;
     }

--- a/src/Raw/Aggregate.php
+++ b/src/Raw/Aggregate.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Formal\ORM\Raw;
 
-use Innmind\Immutable\Set;
+use Innmind\Immutable\Sequence;
 
 /**
  * @psalm-immutable
@@ -11,27 +11,27 @@ use Innmind\Immutable\Set;
 final class Aggregate
 {
     private Aggregate\Id $id;
-    /** @var Set<Aggregate\Property> */
-    private Set $properties;
-    /** @var Set<Aggregate\Entity> */
-    private Set $entities;
-    /** @var Set<Aggregate\Optional> */
-    private Set $optionals;
-    /** @var Set<Aggregate\Collection> */
-    private Set $collections;
+    /** @var Sequence<Aggregate\Property> */
+    private Sequence $properties;
+    /** @var Sequence<Aggregate\Entity> */
+    private Sequence $entities;
+    /** @var Sequence<Aggregate\Optional> */
+    private Sequence $optionals;
+    /** @var Sequence<Aggregate\Collection> */
+    private Sequence $collections;
 
     /**
-     * @param Set<Aggregate\Property> $properties
-     * @param Set<Aggregate\Entity> $entities
-     * @param Set<Aggregate\Optional> $optionals
-     * @param Set<Aggregate\Collection> $collections
+     * @param Sequence<Aggregate\Property> $properties
+     * @param Sequence<Aggregate\Entity> $entities
+     * @param Sequence<Aggregate\Optional> $optionals
+     * @param Sequence<Aggregate\Collection> $collections
      */
     private function __construct(
         Aggregate\Id $id,
-        Set $properties,
-        Set $entities,
-        Set $optionals,
-        Set $collections,
+        Sequence $properties,
+        Sequence $entities,
+        Sequence $optionals,
+        Sequence $collections,
     ) {
         $this->id = $id;
         $this->properties = $properties;
@@ -43,17 +43,17 @@ final class Aggregate
     /**
      * @psalm-pure
      *
-     * @param Set<Aggregate\Property> $properties
-     * @param Set<Aggregate\Entity> $entities
-     * @param Set<Aggregate\Optional> $optionals
-     * @param Set<Aggregate\Collection> $collections
+     * @param Sequence<Aggregate\Property> $properties
+     * @param Sequence<Aggregate\Entity> $entities
+     * @param Sequence<Aggregate\Optional> $optionals
+     * @param Sequence<Aggregate\Collection> $collections
      */
     public static function of(
         Aggregate\Id $id,
-        Set $properties,
-        Set $entities,
-        Set $optionals,
-        Set $collections,
+        Sequence $properties,
+        Sequence $entities,
+        Sequence $optionals,
+        Sequence $collections,
     ): self {
         return new self($id, $properties, $entities, $optionals, $collections);
     }
@@ -64,33 +64,33 @@ final class Aggregate
     }
 
     /**
-     * @return Set<Aggregate\Property>
+     * @return Sequence<Aggregate\Property>
      */
-    public function properties(): Set
+    public function properties(): Sequence
     {
         return $this->properties;
     }
 
     /**
-     * @return Set<Aggregate\Entity>
+     * @return Sequence<Aggregate\Entity>
      */
-    public function entities(): Set
+    public function entities(): Sequence
     {
         return $this->entities;
     }
 
     /**
-     * @return Set<Aggregate\Optional>
+     * @return Sequence<Aggregate\Optional>
      */
-    public function optionals(): Set
+    public function optionals(): Sequence
     {
         return $this->optionals;
     }
 
     /**
-     * @return Set<Aggregate\Collection>
+     * @return Sequence<Aggregate\Collection>
      */
-    public function collections(): Set
+    public function collections(): Sequence
     {
         return $this->collections;
     }

--- a/src/Raw/Diff.php
+++ b/src/Raw/Diff.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Formal\ORM\Raw;
 
-use Innmind\Immutable\Set;
+use Innmind\Immutable\Sequence;
 
 /**
  * @psalm-immutable
@@ -11,27 +11,27 @@ use Innmind\Immutable\Set;
 final class Diff
 {
     private Aggregate\Id $id;
-    /** @var Set<Aggregate\Property> */
-    private Set $properties;
-    /** @var Set<Aggregate\Entity> */
-    private Set $entities;
-    /** @var Set<Aggregate\Optional|Aggregate\Optional\BrandNew> */
-    private Set $optionals;
-    /** @var Set<Aggregate\Collection> */
-    private Set $collections;
+    /** @var Sequence<Aggregate\Property> */
+    private Sequence $properties;
+    /** @var Sequence<Aggregate\Entity> */
+    private Sequence $entities;
+    /** @var Sequence<Aggregate\Optional|Aggregate\Optional\BrandNew> */
+    private Sequence $optionals;
+    /** @var Sequence<Aggregate\Collection> */
+    private Sequence $collections;
 
     /**
-     * @param Set<Aggregate\Property> $properties
-     * @param Set<Aggregate\Entity> $entities
-     * @param Set<Aggregate\Optional|Aggregate\Optional\BrandNew> $optionals
-     * @param Set<Aggregate\Collection> $collections
+     * @param Sequence<Aggregate\Property> $properties
+     * @param Sequence<Aggregate\Entity> $entities
+     * @param Sequence<Aggregate\Optional|Aggregate\Optional\BrandNew> $optionals
+     * @param Sequence<Aggregate\Collection> $collections
      */
     private function __construct(
         Aggregate\Id $id,
-        Set $properties,
-        Set $entities,
-        Set $optionals,
-        Set $collections,
+        Sequence $properties,
+        Sequence $entities,
+        Sequence $optionals,
+        Sequence $collections,
     ) {
         $this->id = $id;
         $this->properties = $properties;
@@ -44,17 +44,17 @@ final class Diff
      * @internal
      * @psalm-pure
      *
-     * @param Set<Aggregate\Property> $properties
-     * @param Set<Aggregate\Entity> $entities
-     * @param Set<Aggregate\Optional|Aggregate\Optional\BrandNew> $optionals
-     * @param Set<Aggregate\Collection> $collections
+     * @param Sequence<Aggregate\Property> $properties
+     * @param Sequence<Aggregate\Entity> $entities
+     * @param Sequence<Aggregate\Optional|Aggregate\Optional\BrandNew> $optionals
+     * @param Sequence<Aggregate\Collection> $collections
      */
     public static function of(
         Aggregate\Id $id,
-        Set $properties,
-        Set $entities,
-        Set $optionals,
-        Set $collections,
+        Sequence $properties,
+        Sequence $entities,
+        Sequence $optionals,
+        Sequence $collections,
     ): self {
         return new self($id, $properties, $entities, $optionals, $collections);
     }
@@ -65,33 +65,33 @@ final class Diff
     }
 
     /**
-     * @return Set<Aggregate\Property>
+     * @return Sequence<Aggregate\Property>
      */
-    public function properties(): Set
+    public function properties(): Sequence
     {
         return $this->properties;
     }
 
     /**
-     * @return Set<Aggregate\Entity>
+     * @return Sequence<Aggregate\Entity>
      */
-    public function entities(): Set
+    public function entities(): Sequence
     {
         return $this->entities;
     }
 
     /**
-     * @return Set<Aggregate\Optional|Aggregate\Optional\BrandNew>
+     * @return Sequence<Aggregate\Optional|Aggregate\Optional\BrandNew>
      */
-    public function optionals(): Set
+    public function optionals(): Sequence
     {
         return $this->optionals;
     }
 
     /**
-     * @return Set<Aggregate\Collection>
+     * @return Sequence<Aggregate\Collection>
      */
-    public function collections(): Set
+    public function collections(): Sequence
     {
         return $this->collections;
     }

--- a/src/Repository/Denormalize.php
+++ b/src/Repository/Denormalize.php
@@ -130,8 +130,7 @@ final class Denormalize
                         ->get($property->name())
                         ->map(static fn($definition): mixed => $definition->type()->denormalize($property->value()))
                         ->map(static fn($value) => [$property->name(), $value])
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 )
                 ->toList(),
             ...$data
@@ -142,8 +141,7 @@ final class Denormalize
                         ->get($entity->name())
                         ->map(static fn($denormalize): object => $denormalize($entity))
                         ->map(static fn($value) => [$entity->name(), $value])
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 )
                 ->toList(),
             ...$data
@@ -154,8 +152,7 @@ final class Denormalize
                         ->get($optional->name())
                         ->map(static fn($denormalize): Maybe => $denormalize($optional))
                         ->map(static fn($value) => [$optional->name(), $value])
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 )
                 ->toList(),
             ...$data
@@ -166,8 +163,7 @@ final class Denormalize
                         ->get($collection->name())
                         ->map(static fn($denormalize): Set => $denormalize($id, $collection))
                         ->map(static fn($value) => [$collection->name(), $value])
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 )
                 ->toList(),
         );

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -120,8 +120,7 @@ final class Diff
                 $property->name(),
                 $property->type()->normalize($value->now()),
             ))
-            ->values()
-            ->toSet();
+            ->values();
         /** @psalm-suppress MixedArgument */
         $entities = $diff
             ->flatMap(
@@ -137,8 +136,7 @@ final class Diff
                         static fn() => Map::of(),
                     ),
             )
-            ->values()
-            ->toSet();
+            ->values();
         /** @psalm-suppress MixedArgument */
         $optionals = $diff
             ->flatMap(
@@ -154,8 +152,7 @@ final class Diff
                         static fn() => Map::of(),
                     ),
             )
-            ->values()
-            ->toSet();
+            ->values();
         /** @psalm-suppress MixedArgument */
         $collections = $diff
             ->flatMap(
@@ -173,8 +170,7 @@ final class Diff
                         static fn() => Map::of(),
                     ),
             )
-            ->values()
-            ->toSet();
+            ->values();
 
         return Raw\Diff::of(
             $normalizedId,

--- a/src/Repository/Extract.php
+++ b/src/Repository/Extract.php
@@ -9,10 +9,7 @@ use Formal\ORM\{
     Id,
 };
 use Innmind\Reflection;
-use Innmind\Immutable\{
-    Set,
-    Map,
-};
+use Innmind\Immutable\Set;
 
 /**
  * @internal
@@ -38,21 +35,22 @@ final class Extract
         $this->allProperties = $definition
             ->properties()
             ->map(static fn($property) => $property->name())
-            ->merge(
+            ->append(
                 $definition
                     ->entities()
                     ->map(static fn($entity) => $entity->name()),
             )
-            ->merge(
+            ->append(
                 $definition
                     ->optionals()
                     ->map(static fn($optional) => $optional->name()),
             )
-            ->merge(
+            ->append(
                 $definition
                     ->collections()
                     ->map(static fn($collection) => $collection->name()),
-            );
+            )
+            ->toSet();
         /**
          * @psalm-suppress InvalidArgument
          * @var \Closure(T): Id<T>

--- a/src/Repository/Normalize.php
+++ b/src/Repository/Normalize.php
@@ -88,8 +88,7 @@ final class Normalize
                             $property->name(),
                             $property->type()->normalize($value),
                         ))
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 ),
             $this
                 ->definition
@@ -103,8 +102,7 @@ final class Normalize
                                 ->get($entity->name())
                                 ->map($normalize),
                         )
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 ),
             $this
                 ->definition
@@ -118,8 +116,7 @@ final class Normalize
                                 ->get($optional->name())
                                 ->map($normalize),
                         )
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 ),
             $this
                 ->definition
@@ -133,8 +130,7 @@ final class Normalize
                                 ->get($collection->name())
                                 ->map(static fn($object) => $normalize($denormalized->id(), $object)),
                         )
-                        ->toSequence()
-                        ->toSet(),
+                        ->toSequence(),
                 ),
         );
     }


### PR DESCRIPTION
## Problem

`Set`s are used to describe a unique collection of properties, entities, etc... Even though this is the right structure conceptually, it adds lots of operations to make sure there are no duplicated objects. But the way the objects are created there can never be multiple instances of the same object inside a collection.

The result is that the time took to verify this unicity is wasted and impacts the overall performance of the ORM.

## Solution

Replace `Set`s by `Sequence`s.