### PR TITLE
Add Elasticsearch `Adapter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: php blackbox.php
         env:
           DB_PORT: ${{ job.services.mariadb.ports[3306] }}
+          ES_PORT: ${{ job.services.elasticsearch.ports[9200] }}
   coverage:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -84,6 +85,7 @@ jobs:
         env:
           ENABLE_COVERAGE: 'true'
           DB_PORT: ${{ job.services.mariadb.ports[3306] }}
+          ES_PORT: ${{ job.services.elasticsearch.ports[9200] }}
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         php-version: ['8.2', '8.3']
         dependency-versions: ['lowest', 'highest']
         mariadb: ['10', '11']
+        elasticsearch: ['7.17.18', '8.12.1']
     name: 'BlackBox'
     services:
       mariadb:
@@ -20,6 +21,10 @@ jobs:
           MYSQL_DATABASE: example
         ports:
             - 3306
+      elasticsearch:
+        image: elasticsearch:${{ matrix.elasticsearch }}
+        ports:
+          - 9200
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -53,6 +58,10 @@ jobs:
           MYSQL_DATABASE: example
         ports:
             - 3306
+      elasticsearch:
+        image: elasticsearch:7.17.18
+        ports:
+          - 9200
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
             - 3306
       elasticsearch:
         image: elasticsearch:${{ matrix.elasticsearch }}
+        env:
+          discovery.type: single-node
         ports:
           - 9200
     steps:
@@ -60,6 +62,8 @@ jobs:
             - 3306
       elasticsearch:
         image: elasticsearch:7.17.18
+        env:
+          discovery.type: single-node
         ports:
           - 9200
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         php-version: ['8.2', '8.3']
         dependency-versions: ['lowest', 'highest']
         mariadb: ['10', '11']
-        elasticsearch: ['7.17.18', '8.12.1']
+        elasticsearch: ['7.17.18']
     name: 'BlackBox'
     services:
       mariadb:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - internally it uses an _entity reference_ but it doesn't impact user classes
 - You can use any enum as a property type (nullable/optional or not)
 - You can use any enum inside `Set`s without having to wrap them in another class
+- `Formal\ORM\Adapter\Elasticsearch` to store aggregates in Elasticsearch
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
         "innmind/json": "~1.3",
         "innmind/time-continuum": "~3.3",
         "innmind/type": "~1.2",
-        "formal/access-layer": "~2.15"
+        "formal/access-layer": "~2.15",
+        "innmind/http-transport": "~7.2",
+        "innmind/url-template": "^3.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "innmind/type": "~1.2",
         "formal/access-layer": "~2.15",
         "innmind/http-transport": "~7.2",
-        "innmind/url-template": "^3.1"
+        "innmind/url-template": "~3.1",
+        "innmind/validation": "~1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "formal/access-layer": "~2.15",
         "innmind/http-transport": "~7.2",
         "innmind/url-template": "~3.1",
-        "innmind/validation": "~1.1"
+        "innmind/validation": "^1.1.1"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,7 @@ services:
             MYSQL_DATABASE: example
         ports:
             - '3306:3306'
+    elasticsearch:
+        image: elasticsearch:7.17.18
+        ports:
+            - '9200:9200'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,7 @@ services:
             - '3306:3306'
     elasticsearch:
         image: elasticsearch:7.17.18
+        environment:
+            discovery.type: single-node
         ports:
             - '9200:9200'

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -24,3 +24,4 @@ Before diving into use cases you should read more about these subjects:
 - [Retrieving multiple aggregates](use_cases/retrieve_aggregates.md)
 - [Using objects in aggregates properties](use_cases/types.md)
 - [Going to production](use_cases/production.md)
+- [Search an aggregate via Elasticsearch](use_cases/elasticsearch.md)

--- a/documentation/adapters.md
+++ b/documentation/adapters.md
@@ -1,6 +1,6 @@
 # Adapters
 
-By default this ORM comes with 2 `Adapter`s: Filesystem and SQL.
+By default this ORM comes with 3 `Adapter`s: Filesystem, SQL and Elasticsearch.
 
 ## Filesystem
 
@@ -16,3 +16,9 @@ You should **not** use this kind of adapter in production.
 This adapter works with any object that implements `Formal\AccessLayer\Connection`. If you use a connection provided by [`innmind/operating-system`](https://packagist.org/packages/innmind/operating-system) then you can use any SQL database supported by `\PDO`.
 
 This is the kind of adapter you want to use in production.
+
+## Elasticsearch
+
+This adapter works with any object that implements `Innmind\HttpTransport\Transport`.
+
+This is the kind of adapter you want to use to denormalize your aggregates to improve the search speed.

--- a/documentation/limitations.md
+++ b/documentation/limitations.md
@@ -3,3 +3,16 @@
 Due to the current design of entities not having ids it is not possible to build a complete diff of collections of entities. This means that as soon as an entity is modified the whole object is persisted to the storage.
 
 For small entities this is fine but can become quite time consuming if you store a lot of data inside a given entity.
+
+## Elasticsearch
+
+This adapter has 2 major limitations:
+- it does not support transactions
+- it can't list more than 10k aggregates
+
+Elasticsearch have no concept of transactions. The adapter implementation do not try to emulate a transaction mechanism as it would be too complex. This means that has soon you make an operation on a repository the change is directly applied to the underlying index.
+
+The Elasticsearch api doesn't allow a pagination above 10k documents. This is a hardcoded behaviour on their part, this is a design choice as to not interpret an index as a database. This means that if you have more than 10k aggregates you won't be able to list them all.
+
+> [!CAUTION]
+> These limitations mean that you can't swap another adapter by this one without behaviours changes in your app.

--- a/documentation/use_cases/elasticsearch.md
+++ b/documentation/use_cases/elasticsearch.md
@@ -116,3 +116,30 @@ $_ = $sql
 ```
 
 Then you can search these new aggregates [as any other](retrieve_aggregates.md)
+
+## Managing the indexes for the aggregates
+
+In order to persist the aggregates to Elasticsearch you need to create the underlying index via:
+
+```php
+use Formal\ORM\{
+    Definition\Aggregates,
+    Definition\Types,
+    Adapter\Elasticsearch\CreateIndex,
+};
+use Innmind\OperatingSystem\Factory;
+use Innmind\Url\Url;
+
+$createIndex = CreateIndex::of(
+    Factory::build()->remote()->http(),
+    Aggregates::of(Types::default()),
+    Url::of('http://localhost:9200/'),
+);
+
+$createIndex(Search\Product::class)->match(
+    static fn() => null,
+    static fn() => throw new \RuntimeException('Unable to create the index'),
+);
+```
+
+And to drop an index you can use `Formal\ORM\Adapter\Elasticsearch\DropIndex`.

--- a/documentation/use_cases/elasticsearch.md
+++ b/documentation/use_cases/elasticsearch.md
@@ -1,0 +1,118 @@
+# Search an aggregate via Elasticsearch
+
+If you have multiple aggregates (let's say `Product` and `Vendor`) that you want to query in a single specification, you'll need to create a third aggregate (ie `Search\Product`) that will denormalize the data of both aggregates.
+
+These aggregates may look like this:
+
+```php
+use Formal\ORM\Id;
+
+final class Product
+{
+    /** @var Id<self> */
+    private Id $id;
+    private string $name;
+    /** @var Id<Vendor> */
+    private Id $vendor;
+
+    /**
+     * @param Id<Vendor> $vendor
+     */
+    public function __construct(string $name, Id $vendor)
+    {
+        $this->id = Id::new(self::class);
+        $this->name = $name;
+        $this->vendor = $vendor;
+    }
+
+    // Getters not displayed for conciseness
+}
+```
+
+```php
+use Formal\ORM\Id;
+
+final class Vendor
+{
+    /** @var Id<self> */
+    private Id $id;
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->id = Id::new(self::class);
+        $this->name = $name;
+    }
+
+    // Getters not displayed for conciseness
+}
+```
+
+```php
+namespace Search;
+
+use Formal\ORM\Id;
+
+final class Product
+{
+    /** @var Id<self> */
+    private Id $id;
+    /** @var Id<\Product> */
+    private Id $productId;
+    private string $productName;
+    /** @var Id<\Vendor> */
+    private Id $vendorId;
+    private string $vendorName;
+
+    public function __construct(\Product $product, \Vendor $vendor)
+    {
+        $this->id = Id::new(self::class);
+        $this->productId = $product->id();
+        $this->productName = $product->name();
+        $this->vendorId = $vendor->id();
+        $this->vendorName = $vendor->name();
+    }
+}
+```
+
+And to persist this new aggregate you would use 2 instances of the ORM like this:
+
+```php
+use Formal\ORM\{
+    Manager,
+    Adapter\Elasticsearch,
+};
+use Innmind\OperatingSystem\Factory;
+use Innmind\Url\Url;
+use Innmind\Immutable\Either;
+
+$os = Factory::build();
+$sql = Manager::sql(
+    $os->remote()->sql(Url::of('mysql://user:password@host:3306/database?charset=utf8mb4')),
+);
+$elasticsearch = Manager::of(
+    Elasticsearch::of($os->remote()->http()),
+);
+
+$vendors = $sql->repository(Vendor::class);
+$_ = $sql
+    ->repository(Product::class)
+    ->all()
+    ->flatMap(
+        static fn($product) => $vendors
+            ->get($product->vendor())
+            ->map(static fn($vendor) => new Search\Product($product, $vendor))
+            ->toSequence(), // if the vendor doesn't exist the product is discarded
+    )
+    ->foreach(
+        static fn($searchableProduct) => $elasticsearch->transactional(
+            static fn() => Either::right(
+                $elasticsearch
+                    ->repository(Search\Product::class)
+                    ->put($searchableProduct),
+            ),
+        ),
+    );
+```
+
+Then you can search these new aggregates [as any other](retrieve_aggregates.md)

--- a/documentation/use_cases/types.md
+++ b/documentation/use_cases/types.md
@@ -114,6 +114,9 @@ And there's nothing more to do, now when persisting the ORM will automatically t
 
 But if you noticed the property in `User` is nullable but we didn't handle this case in our type converter. The ORM automatically handles that for you via type composition.
 
+> [!TIP]
+> Your type class can also implement `Formal\ORM\Adapter\SQL\SQLType` or `Formal\ORM\Adapter\Elasticsearch\ElasticsearchType` to inform the adapter how to better persist your data.
+
 ## My object can't be stored to a single primitive value
 
 Then your object is what is called an Entity in this ORM. If this object is always present in your aggregate then you have nothing to do, the ORM will automatically consider this property as a required entity.

--- a/fixtures/Sortable.php
+++ b/fixtures/Sortable.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace Fixtures\Formal\ORM;
+
+/**
+ * @psalm-immutable
+ */
+final class Sortable
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function of(?string $value): ?self
+    {
+        return match ($value) {
+            null => null,
+            default => new self($value),
+        };
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/fixtures/SortableType.php
+++ b/fixtures/SortableType.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types = 1);
+
+namespace Fixtures\Formal\ORM;
+
+use Fixtures\Formal\ORM\Sortable;
+use Formal\ORM\Adapter\Elasticsearch\ElasticsearchType;
+use Formal\ORM\Definition\{
+    Type,
+    Types,
+};
+use Innmind\Type\{
+    Type as Concrete,
+    ClassName,
+};
+use Innmind\Immutable\Maybe;
+
+/**
+ * @psalm-immutable
+ * @implements Type<Sortable>
+ */
+final class SortableType implements Type, ElasticsearchType
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @return Maybe<self>
+     */
+    public static function of(Types $types, Concrete $type): Maybe
+    {
+        return Maybe::just($type)
+            ->filter(static fn($type) => $type->accepts(ClassName::of(Sortable::class)))
+            ->map(static fn() => new self);
+    }
+
+    public function elasticsearchType(): array
+    {
+        return ['type' => 'keyword'];
+    }
+
+    public function normalize(mixed $value): null|string|int|bool
+    {
+        return $value->toString();
+    }
+
+    public function denormalize(null|string|int|bool $value): mixed
+    {
+        if (!\is_string($value)) {
+            throw new \LogicException("'$value' is not a string");
+        }
+
+        return new Sortable($value);
+    }
+}

--- a/fixtures/User.php
+++ b/fixtures/User.php
@@ -23,6 +23,11 @@ final class User
     /** @var Maybe<Str> */
     #[Contains(Str::class)]
     private Maybe $nameStr;
+    /**
+     * This property is necessary for the Elasticsearch adapter that requires
+     * the field being sorted on to be a keyword
+     */
+    private ?Sortable $sortableName;
     private User\Address $mainAddress;
     /** @var Maybe<User\Address> */
     #[Contains(User\Address::class)]
@@ -58,6 +63,7 @@ final class User
         $this->createdAt = $createdAt;
         $this->name = $name;
         $this->nameStr = Maybe::of($name)->map(Str::of(...));
+        $this->sortableName = Sortable::of($name);
         $this->mainAddress = $mainAddress;
         $this->billingAddress = $billingAddress;
         $this->addresses = $addresses;

--- a/fixtures/User/Address.php
+++ b/fixtures/User/Address.php
@@ -3,13 +3,21 @@ declare(strict_types = 1);
 
 namespace Fixtures\Formal\ORM\User;
 
+use Fixtures\Formal\ORM\Sortable;
+
 final class Address
 {
     private string $value;
+    /**
+     * This property is necessary for the Elasticsearch adapter that requires
+     * the field being sorted on to be a keyword
+     */
+    private Sortable $sortable;
 
     private function __construct(string $value)
     {
         $this->value = $value;
+        $this->sortable = new Sortable($value);
     }
 
     public static function new(string $value): self

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -56,16 +56,32 @@ return static function() {
                         'addresses' => [
                             'type' => 'nested',
                             'properties' => [
-                                'value' => [
-                                    'type' => 'text',
+                                'reference' => [
+                                    'type' => 'keyword',
+                                    'index' => false,
+                                ],
+                                'data' => [
+                                    'properties' => [
+                                        'value' => [
+                                            'type' => 'text',
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],
                         'roles' => [
                             'type' => 'nested',
                             'properties' => [
-                                'name' => [
-                                    'type' => 'text',
+                                'reference' => [
+                                    'type' => 'keyword',
+                                    'index' => false,
+                                ],
+                                'data' => [
+                                    'properties' => [
+                                        'name' => [
+                                            'type' => 'text',
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+use Formal\ORM\{
+    Adapter\Elasticsearch\Mapping,
+    Definition\Aggregates,
+    Definition\Type,
+    Definition\Types,
+};
+use Innmind\TimeContinuum\Earth\Clock;
+use Fixtures\Formal\ORM\User;
+
+return static function() {
+    yield test(
+        'Define Elasticsearch index mapping for the User fixture',
+        static function($assert) {
+            $aggregates = Aggregates::of(Types::of(
+                Type\PointInTimeType::of(new Clock),
+            ));
+
+            $mapping = Mapping::of($aggregates->get(User::class))();
+
+            $assert
+                ->expected([
+                    'properties' => [
+                        'id' => [
+                            'type' => 'keyword',
+                            'index' => false,
+                        ],
+                        'createdAt' => [
+                            'type' => 'date_nanos',
+                        ],
+                        'name' => [
+                            'type' => 'text',
+                        ],
+                        'nameStr' => [
+                            'type' => 'text',
+                        ],
+                        'role' => [
+                            'type' => 'text',
+                        ],
+                        'mainAddress' => [
+                            'properties' => [
+                                'value' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                        ],
+                        'billingAddress' => [
+                            'properties' => [
+                                'value' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                        ],
+                        'addresses' => [
+                            'type' => 'nested',
+                            'properties' => [
+                                'value' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                        ],
+                        'roles' => [
+                            'type' => 'nested',
+                            'properties' => [
+                                'name' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                        ],
+                    ],
+                ])
+                ->same($mapping);
+        },
+    );
+};

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -19,7 +19,7 @@ return static function() {
                 Type\PointInTimeType::of(new Clock),
             ));
 
-            $mapping = Mapping::of($aggregates->get(User::class))();
+            $mapping = Mapping::new()($aggregates->get(User::class));
 
             $assert
                 ->expected([

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -29,7 +29,7 @@ return static function() {
                             'index' => false,
                         ],
                         'createdAt' => [
-                            'type' => 'date_nanos',
+                            'type' => 'text',
                         ],
                         'name' => [
                             'type' => 'text',

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -26,7 +26,6 @@ return static function() {
                     'properties' => [
                         'id' => [
                             'type' => 'keyword',
-                            'index' => false,
                         ],
                         'createdAt' => [
                             'type' => 'text',

--- a/proofs/manager.php
+++ b/proofs/manager.php
@@ -14,6 +14,7 @@ use Formal\ORM\{
 use Fixtures\Formal\ORM\{
     User,
     Random,
+    SortableType,
 };
 use Properties\Formal\ORM\Properties;
 use Formal\AccessLayer\{
@@ -78,6 +79,7 @@ return static function() {
             InMemory::emulateFilesystem(),
             Aggregates::of(Types::of(
                 Type\PointInTimeType::of(new Clock),
+                SortableType::of(...),
             )),
         )),
     );
@@ -89,6 +91,7 @@ return static function() {
                 InMemory::emulateFilesystem(),
                 Aggregates::of(Types::of(
                     Type\PointInTimeType::of(new Clock),
+                    SortableType::of(...),
                 )),
             )),
         )->named('Filesystem');
@@ -100,6 +103,7 @@ return static function() {
     $connection = $os->remote()->sql(Url::of("mysql://root:root@127.0.0.1:$port/example"));
     $aggregates = Aggregates::of(Types::of(
         Type\PointInTimeType::of(new Clock),
+        SortableType::of(...),
     ));
     $connection(DropTable::ifExists(Table\Name::of('user_roles')));
     $connection(DropTable::ifExists(Table\Name::of('user_addresses')));

--- a/proofs/manager.php
+++ b/proofs/manager.php
@@ -16,7 +16,11 @@ use Fixtures\Formal\ORM\{
     Random,
     SortableType,
 };
-use Properties\Formal\ORM\Properties;
+use Properties\Formal\ORM\{
+    Properties,
+    FailingTransactionDueToLeftSide,
+    FailingTransactionDueToException,
+};
 use Formal\AccessLayer\{
     Query\DropTable,
     Query\SQL,
@@ -166,11 +170,19 @@ return static function() {
 
     yield properties(
         'Elasticsearch properties',
-        Properties::any(),
+        Properties::any(Properties::withoutTransactions()),
         Set\Call::of($setup),
     );
 
     foreach (Properties::alwaysApplicable() as $property) {
+        if (\in_array(
+            $property,
+            [FailingTransactionDueToLeftSide::class, FailingTransactionDueToException::class],
+            true,
+        )) {
+            continue;
+        }
+
         yield property(
             $property,
             Set\Call::of($setup),

--- a/proofs/manager.php
+++ b/proofs/manager.php
@@ -6,6 +6,7 @@ use Formal\ORM\{
     Adapter,
     Adapter\Elasticsearch\CreateIndex,
     Adapter\Elasticsearch\DropIndex,
+    Adapter\Elasticsearch\Refresh,
     Definition\Aggregates,
     Definition\Types,
     Definition\Type,
@@ -151,7 +152,10 @@ return static function() {
             );
 
         return Manager::of(
-            Adapter\Elasticsearch::of($os->remote()->http(), $url),
+            Adapter\Elasticsearch::of(
+                Refresh::of($os->remote()->http()),
+                $url,
+            ),
             $aggregates,
         );
     };

--- a/properties/MatchingSort.php
+++ b/properties/MatchingSort.php
@@ -79,7 +79,7 @@ final class MatchingSort implements Property
                 Sign::startsWith,
                 Str::of($this->prefix),
             ))
-            ->sort('nameStr', Sort::asc)
+            ->sort('sortableName', Sort::asc)
             ->map(static fn($user) => $user->id()->toString())
             ->toList();
 
@@ -95,7 +95,7 @@ final class MatchingSort implements Property
                 Sign::startsWith,
                 Str::of($this->prefix),
             ))
-            ->sort('nameStr', Sort::desc)
+            ->sort('sortableName', Sort::desc)
             ->map(static fn($user) => $user->id()->toString())
             ->toList();
 

--- a/properties/MatchingSortEntity.php
+++ b/properties/MatchingSortEntity.php
@@ -78,7 +78,7 @@ final class MatchingSortEntity implements Property
                 Sign::startsWith,
                 $this->prefix,
             ))
-            ->sort('mainAddress.value', Sort::asc)
+            ->sort('mainAddress.sortable', Sort::asc)
             ->map(static fn($user) => $user->id()->toString())
             ->toList();
 
@@ -94,7 +94,7 @@ final class MatchingSortEntity implements Property
                 Sign::startsWith,
                 $this->prefix,
             ))
-            ->sort('mainAddress.value', Sort::desc)
+            ->sort('mainAddress.sortable', Sort::desc)
             ->map(static fn($user) => $user->id()->toString())
             ->toList();
 

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -10,12 +10,12 @@ use Innmind\BlackBox\{
 
 final class Properties
 {
-    public static function any(): Set\Properties
+    public static function any(array $properties = null): Set\Properties
     {
         return Set\Properties::any(
             ...\array_map(
                 static fn($property) => [$property, 'any'](),
-                self::list(),
+                $properties ?? self::list(),
             ),
         );
     }
@@ -63,6 +63,24 @@ final class Properties
             AddElementToCollections::class,
             ListingAggregatesUseConstantMemory::class,
         ];
+    }
+
+    /**
+     * @return non-empty-list<class-string<Property>>
+     */
+    public static function withoutTransactions(): array
+    {
+        return \array_values(\array_filter(
+            self::list(),
+            static fn($class) => !\in_array(
+                $class,
+                [
+                    FailingTransactionDueToLeftSide::class,
+                    FailingTransactionDueToException::class,
+                ],
+                true,
+            ),
+        ));
     }
 
     /**

--- a/src/Adapter/Elasticsearch.php
+++ b/src/Adapter/Elasticsearch.php
@@ -32,7 +32,6 @@ final class Elasticsearch implements Adapter
     {
         return Elasticsearch\Repository::of(
             $this->transport,
-            $this->transaction,
             $definition,
             $this->url,
         );

--- a/src/Adapter/Elasticsearch.php
+++ b/src/Adapter/Elasticsearch.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter;
+
+use Formal\ORM\{
+    Adapter,
+    Definition\Aggregate,
+};
+use Innmind\HttpTransport\Transport;
+use Innmind\Url\Url;
+
+final class Elasticsearch implements Adapter
+{
+    private Transport $transport;
+    private Url $url;
+    private Elasticsearch\Transaction $transaction;
+
+    private function __construct(Transport $transport, Url $url)
+    {
+        $this->transport = $transport;
+        $this->url = $url;
+        $this->transaction = Elasticsearch\Transaction::of();
+    }
+
+    public static function of(Transport $transport, Url $url): self
+    {
+        return new self($transport, $url);
+    }
+
+    public function repository(Aggregate $definition): Repository
+    {
+        return Elasticsearch\Repository::of(
+            $this->transport,
+            $this->transaction,
+            $definition,
+            $this->url,
+        );
+    }
+
+    public function transaction(): Transaction
+    {
+        return $this->transaction;
+    }
+}

--- a/src/Adapter/Elasticsearch.php
+++ b/src/Adapter/Elasticsearch.php
@@ -23,9 +23,9 @@ final class Elasticsearch implements Adapter
         $this->transaction = Elasticsearch\Transaction::of();
     }
 
-    public static function of(Transport $transport, Url $url): self
+    public static function of(Transport $transport, Url $url = null): self
     {
-        return new self($transport, $url);
+        return new self($transport, $url ?? Url::of('http://localhost:9200/'));
     }
 
     public function repository(Aggregate $definition): Repository

--- a/src/Adapter/Elasticsearch/CreateIndex.php
+++ b/src/Adapter/Elasticsearch/CreateIndex.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\Definition\Aggregates;
+use Innmind\HttpTransport\Transport;
+use Innmind\Filesystem\File\Content;
+use Innmind\Http\{
+    Request,
+    Method,
+    ProtocolVersion,
+    Headers,
+    Header\ContentType,
+};
+use Innmind\Url\{
+    Url,
+    Path,
+};
+use Innmind\Json\Json;
+use Innmind\Immutable\{
+    Maybe,
+    SideEffect,
+};
+
+final class CreateIndex
+{
+    private Transport $http;
+    private Aggregates $aggregates;
+    private Mapping $mapping;
+    private Url $url;
+
+    private function __construct(
+        Transport $http,
+        Aggregates $aggregates,
+        Url $url,
+    ) {
+        $this->http = $http;
+        $this->aggregates = $aggregates;
+        $this->mapping = Mapping::new();
+        $this->url = $url;
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return Maybe<SideEffect>
+     */
+    public function __invoke(string $class): Maybe
+    {
+        $definition = $this->aggregates->get($class);
+
+        return ($this->http)(Request::of(
+            $this->url->withPath(
+                Path::of('/'.$definition->name()),
+            ),
+            Method::put,
+            ProtocolVersion::v11,
+            Headers::of(
+                ContentType::of('application', 'json'),
+            ),
+            Content::ofString(Json::encode([
+                'mappings' => ($this->mapping)($definition),
+            ])),
+        ))
+            ->maybe()
+            ->map(static fn() => new SideEffect);
+    }
+
+    public static function of(
+        Transport $transport,
+        Aggregates $aggregates,
+        Url $url,
+    ): self {
+        return new self($transport, $aggregates, $url);
+    }
+}

--- a/src/Adapter/Elasticsearch/Decode.php
+++ b/src/Adapter/Elasticsearch/Decode.php
@@ -1,0 +1,259 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\{
+    Definition\Aggregate as Definition,
+    Raw\Aggregate,
+};
+use Innmind\Filesystem\File\Content;
+use Innmind\Json\Json;
+use Innmind\Validation\{
+    Constraint,
+    Shape,
+    Is,
+    Each,
+    Of,
+};
+use Innmind\Immutable\{
+    Maybe,
+    Sequence,
+    Validation,
+    Set,
+};
+
+/**
+ * @internal
+ * @template T of object
+ */
+final class Decode
+{
+    /** @var Definition<T> */
+    private Definition $definition;
+    /** @var Constraint<mixed, Sequence<Aggregate\Property>> */
+    private Constraint $properties;
+    /** @var Constraint<array, Sequence<Aggregate\Entity>> */
+    private Constraint $entities;
+    /** @var Constraint<array, Sequence<Aggregate\Optional>> */
+    private Constraint $optionals;
+    /** @var Constraint<array, Sequence<Aggregate\Collection>> */
+    private Constraint $collections;
+
+    /**
+     * @param Definition<T> $definition
+     */
+    private function __construct(Definition $definition)
+    {
+        $this->definition = $definition;
+        $this->properties = self::properties($definition->properties());
+        /** @var Constraint<array, Sequence<Aggregate\Entity>> */
+        $this->entities = $definition
+            ->entities()
+            ->match(
+                static fn($entity, $entities) => $entities
+                    ->reduce(
+                        Shape::of(
+                            $entity->name(),
+                            self::entity($entity),
+                        ),
+                        static fn(Shape $constraint, $entity) => $constraint->with(
+                            $entity->name(),
+                            self::entity($entity),
+                        ),
+                    )
+                    ->map(static fn(array $entities) => Sequence::of(
+                        ...\array_values($entities),
+                    )),
+                static fn() => Of::callable(static fn() => Validation::success(Sequence::of())),
+            );
+        /** @var Constraint<array, Sequence<Aggregate\Optional>> */
+        $this->optionals = $definition
+            ->optionals()
+            ->match(
+                static fn($optional, $optionals) => $optionals
+                    ->reduce(
+                        Shape::of(
+                            $optional->name(),
+                            self::optional($optional),
+                        ),
+                        static fn(Shape $constraint, $optional) => $constraint->with(
+                            $optional->name(),
+                            self::optional($optional),
+                        ),
+                    )
+                    ->map(static fn(array $optionals) => Sequence::of(
+                        ...\array_values($optionals),
+                    )),
+                static fn() => Of::callable(static fn() => Validation::success(Sequence::of())),
+            );
+        /** @var Constraint<array, Sequence<Aggregate\Collection>> */
+        $this->collections = $definition
+            ->collections()
+            ->match(
+                static fn($collection, $collections) => $collections
+                    ->reduce(
+                        Shape::of(
+                            $collection->name(),
+                            self::collection($collection),
+                        ),
+                        static fn(Shape $constraint, $collection) => $constraint->with(
+                            $collection->name(),
+                            self::collection($collection),
+                        ),
+                    )
+                    ->map(static fn(array $collections) => Sequence::of(
+                        ...\array_values($collections),
+                    )),
+                static fn() => Of::callable(static fn() => Validation::success(Sequence::of())),
+            );
+    }
+
+    /**
+     * @return callable(Content): Maybe<Aggregate>
+     */
+    public function __invoke(Aggregate\Id $id = null): callable
+    {
+        $property = $this->definition->id()->property();
+        /**
+         * @psalm-suppress MixedArgument
+         * @var Constraint<array, Aggregate\Id>
+         */
+        $id = match ($id) {
+            null => Shape::of(
+                $property,
+                Is::string(),
+            )->map(static fn(array $content) => Aggregate\Id::of(
+                $property,
+                $content[$property],
+            )),
+            default => Of::callable(static fn() => Validation::success($id)),
+        };
+
+        return fn(Content $content) => Maybe::just($content->toString())
+            ->map(Json::decode(...))
+            ->flatMap(
+                fn($content) => Maybe::all(
+                    Is::array()->and($id)($content)->maybe(),
+                    ($this->properties)($content)->maybe(),
+                    Is::array()->and($this->entities)($content)->maybe(),
+                    Is::array()->and($this->optionals)($content)->maybe(),
+                    Is::array()->and($this->collections)($content)->maybe(),
+                )->map(Aggregate::of(...)),
+            );
+    }
+
+    /**
+     * @internal
+     * @template A of object
+     *
+     * @param Definition<A> $definition
+     *
+     * @return self<A>
+     */
+    public static function of(Definition $definition): self
+    {
+        return new self($definition);
+    }
+
+    /**
+     * @return Constraint<mixed, Aggregate\Entity>
+     */
+    private static function entity(Definition\Entity $entity): Constraint
+    {
+        return self::properties($entity->properties())->map(
+            static fn($properties) => Aggregate\Entity::of(
+                $entity->name(),
+                $properties,
+            ),
+        );
+    }
+
+    /**
+     * @return Constraint<mixed, Aggregate\Optional>
+     */
+    private static function optional(Definition\Optional $optional): Constraint
+    {
+        return Is::null()
+            ->or(self::properties($optional->properties()))
+            ->map(Maybe::of(...))
+            ->map(
+                static fn($properties) => Aggregate\Optional::of(
+                    $optional->name(),
+                    $properties,
+                ),
+            );
+    }
+
+    /**
+     * @return Constraint<mixed, Aggregate\Collection>
+     */
+    private static function collection(Definition\Collection $collection): Constraint
+    {
+        /** @psalm-suppress MixedArgument Due to the array keys */
+        return Is::array()
+            ->and(Is::list())
+            ->and(Each::of(
+                Shape::of(
+                    'reference',
+                    Is::string()->map(Aggregate\Collection\Entity\Reference::of(...)),
+                )
+                    ->with(
+                        'data',
+                        self::properties($collection->properties()),
+                    )
+                    ->map(static fn(array $entity) => Aggregate\Collection\Entity::of(
+                        $entity['reference'],
+                        $entity['data'],
+                    )),
+            ))
+            ->map(static fn($entities) => Set::of(...$entities))
+            ->map(
+                static fn($entities) => Aggregate\Collection::of(
+                    $collection->name(),
+                    $entities,
+                ),
+            );
+    }
+
+    /**
+     * @param Sequence<Definition\Property> $properties
+     *
+     * @return Constraint<mixed, Sequence<Aggregate\Property>>
+     */
+    private static function properties(Sequence $properties): Constraint
+    {
+        /** @var Constraint<mixed, Sequence<Aggregate\Property>> */
+        return $properties->match(
+            static fn($property, $properties) => Is::array()->and(
+                $properties
+                    ->reduce(
+                        Shape::of($property->name(), self::property($property)),
+                        static fn(Shape $constraint, $property) => $constraint->with(
+                            $property->name(),
+                            self::property($property),
+                        ),
+                    )
+                    ->map(static fn(array $properties) => Sequence::of(
+                        ...\array_values($properties),
+                    )),
+            ),
+            static fn() => Of::callable(static fn() => Validation::success(Sequence::of())),
+        );
+    }
+
+    /**
+     * @return Constraint<mixed, Aggregate\Property>
+     */
+    private static function property(Definition\Property $property): Constraint
+    {
+        return Is::null()
+            ->or(Is::string())
+            ->or(Is::int())
+            ->or(Is::bool())
+            ->map(static fn($value) => Aggregate\Property::of(
+                $property->name(),
+                $value,
+            ));
+    }
+}

--- a/src/Adapter/Elasticsearch/Decode.php
+++ b/src/Adapter/Elasticsearch/Decode.php
@@ -7,8 +7,6 @@ use Formal\ORM\{
     Definition\Aggregate as Definition,
     Raw\Aggregate,
 };
-use Innmind\Filesystem\File\Content;
-use Innmind\Json\Json;
 use Innmind\Validation\{
     Constraint,
     Shape,
@@ -110,7 +108,7 @@ final class Decode
     }
 
     /**
-     * @return callable(Content): Maybe<Aggregate>
+     * @return callable(mixed): Maybe<Aggregate>
      */
     public function __invoke(Aggregate\Id $id = null): callable
     {
@@ -130,17 +128,13 @@ final class Decode
             default => Of::callable(static fn() => Validation::success($id)),
         };
 
-        return fn(Content $content) => Maybe::just($content->toString())
-            ->map(Json::decode(...))
-            ->flatMap(
-                fn($content) => Maybe::all(
-                    Is::array()->and($id)($content)->maybe(),
-                    ($this->properties)($content)->maybe(),
-                    Is::array()->and($this->entities)($content)->maybe(),
-                    Is::array()->and($this->optionals)($content)->maybe(),
-                    Is::array()->and($this->collections)($content)->maybe(),
-                )->map(Aggregate::of(...)),
-            );
+        return fn(mixed $content) => Maybe::all(
+            Is::array()->and($id)($content)->maybe(),
+            ($this->properties)($content)->maybe(),
+            Is::array()->and($this->entities)($content)->maybe(),
+            Is::array()->and($this->optionals)($content)->maybe(),
+            Is::array()->and($this->collections)($content)->maybe(),
+        )->map(Aggregate::of(...));
     }
 
     /**

--- a/src/Adapter/Elasticsearch/DropIndex.php
+++ b/src/Adapter/Elasticsearch/DropIndex.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\Definition\Aggregates;
+use Innmind\HttpTransport\Transport;
+use Innmind\Http\{
+    Request,
+    Method,
+    ProtocolVersion,
+};
+use Innmind\Url\{
+    Url,
+    Path,
+    Query,
+};
+use Innmind\Immutable\{
+    Maybe,
+    SideEffect,
+};
+
+final class DropIndex
+{
+    private Transport $http;
+    private Aggregates $aggregates;
+    private Url $url;
+
+    private function __construct(
+        Transport $http,
+        Aggregates $aggregates,
+        Url $url,
+    ) {
+        $this->http = $http;
+        $this->aggregates = $aggregates;
+        $this->url = $url;
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return Maybe<SideEffect>
+     */
+    public function __invoke(string $class): Maybe
+    {
+        $definition = $this->aggregates->get($class);
+
+        return ($this->http)(Request::of(
+            $this
+                ->url
+                ->withPath(Path::of('/'.$definition->name()))
+                ->withQuery(Query::of('ignore_unavailable=true')),
+            Method::delete,
+            ProtocolVersion::v11,
+        ))
+            ->maybe()
+            ->map(static fn() => new SideEffect);
+    }
+
+    public static function of(
+        Transport $transport,
+        Aggregates $aggregates,
+        Url $url,
+    ): self {
+        return new self($transport, $aggregates, $url);
+    }
+}

--- a/src/Adapter/Elasticsearch/ElasticsearchType.php
+++ b/src/Adapter/Elasticsearch/ElasticsearchType.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+/**
+ * @psalm-immutable
+ */
+interface ElasticsearchType
+{
+    /**
+     * @return array{
+     *     type: string,
+     *     index?: bool,
+     * }
+     */
+    public function elasticsearchType(): array;
+}

--- a/src/Adapter/Elasticsearch/Encode.php
+++ b/src/Adapter/Elasticsearch/Encode.php
@@ -40,7 +40,10 @@ final class Encode
             ->map(fn($collection) => [
                 $collection->name() => $collection
                     ->entities()
-                    ->map(fn($entity) => $this->properties($entity->properties()))
+                    ->map(fn($entity) => [
+                        'reference' => $entity->reference()->toString(),
+                        'data' => $this->properties($entity->properties()),
+                    ])
                     ->toList(),
             ])
             ->toList();

--- a/src/Adapter/Elasticsearch/Encode.php
+++ b/src/Adapter/Elasticsearch/Encode.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\Raw\Aggregate;
+use Innmind\Filesystem\File\Content;
+use Innmind\Json\Json;
+use Innmind\Immutable\Sequence;
+
+/**
+ * @internal
+ */
+final class Encode
+{
+    private function __construct()
+    {
+    }
+
+    public function __invoke(Aggregate $data): Content
+    {
+        $properties = $this->properties($data->properties());
+        $entities = $data
+            ->entities()
+            ->map(fn($entity) => [
+                $entity->name() => $this->properties($entity->properties()),
+            ])
+            ->toList();
+        $optionals = $data
+            ->optionals()
+            ->map(fn($optional) => [
+                $optional->name() => $optional->properties()->match(
+                    $this->properties(...),
+                    static fn() => null,
+                ),
+            ])
+            ->toList();
+        $collections = $data
+            ->collections()
+            ->map(fn($collection) => [
+                $collection->name() => $collection
+                    ->entities()
+                    ->map(fn($entity) => $this->properties($entity->properties()))
+                    ->toList(),
+            ])
+            ->toList();
+
+        return Content::ofString(Json::encode(\array_merge(
+            [$data->id()->name() => $data->id()->value()],
+            $properties,
+            ...$entities,
+            ...$optionals,
+            ...$collections,
+        )));
+    }
+
+    public static function new(): self
+    {
+        return new self;
+    }
+
+    /**
+     * @param Sequence<Aggregate\Property> $properties
+     */
+    private function properties(Sequence $properties): array
+    {
+        return \array_merge(
+            ...$properties
+                ->map(static fn($property) => [$property->name() => $property->value()])
+                ->toList(),
+        );
+    }
+}

--- a/src/Adapter/Elasticsearch/MapType.php
+++ b/src/Adapter/Elasticsearch/MapType.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\Definition\Type;
+
+/**
+ * @psalm-immutable
+ */
+final class MapType
+{
+    private function __construct()
+    {
+    }
+
+    public function __invoke(Type $type): array
+    {
+        return match (true) {
+            $type instanceof ElasticsearchType => $type->elasticsearchType(),
+            $type instanceof Type\NullableType,
+            $type instanceof Type\MaybeType => $this($type->inner()),
+            $type instanceof Type\BoolType => ['type' => 'boolean'],
+            $type instanceof Type\IdType => ['type' => 'keyword'],
+            $type instanceof Type\IntType => ['type' => 'long'],
+            $type instanceof Type\PointInTimeType => ['type' => 'date_nanos'],
+            default => ['type' => 'text'],
+        };
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function new(): self
+    {
+        return new self;
+    }
+}

--- a/src/Adapter/Elasticsearch/MapType.php
+++ b/src/Adapter/Elasticsearch/MapType.php
@@ -23,7 +23,6 @@ final class MapType
             $type instanceof Type\BoolType => ['type' => 'boolean'],
             $type instanceof Type\IdType => ['type' => 'keyword'],
             $type instanceof Type\IntType => ['type' => 'long'],
-            $type instanceof Type\PointInTimeType => ['type' => 'date_nanos'],
             default => ['type' => 'text'],
         };
     }

--- a/src/Adapter/Elasticsearch/MapType.php
+++ b/src/Adapter/Elasticsearch/MapType.php
@@ -6,6 +6,7 @@ namespace Formal\ORM\Adapter\Elasticsearch;
 use Formal\ORM\Definition\Type;
 
 /**
+ * @internal
  * @psalm-immutable
  */
 final class MapType

--- a/src/Adapter/Elasticsearch/Mapping.php
+++ b/src/Adapter/Elasticsearch/Mapping.php
@@ -48,10 +48,7 @@ final class Mapping
             ->toList();
 
         return ['properties' => \array_merge(
-            [$definition->id()->property() => [
-                'type' => 'keyword',
-                'index' => false,
-            ]],
+            [$definition->id()->property() => ['type' => 'keyword']],
             $properties,
             ...$entities,
             ...$optionals,

--- a/src/Adapter/Elasticsearch/Mapping.php
+++ b/src/Adapter/Elasticsearch/Mapping.php
@@ -39,10 +39,18 @@ final class Mapping
             ->toList();
         $collections = $definition
             ->collections()
-            ->map(fn($optional) => [
-                $optional->name() => [
+            ->map(fn($collection) => [
+                $collection->name() => [
                     'type' => 'nested',
-                    'properties' => $this->properties($optional->properties()),
+                    'properties' => [
+                        'reference' => [
+                            'type' => 'keyword',
+                            'index' => false,
+                        ],
+                        'data' => [
+                            'properties' => $this->properties($collection->properties()),
+                        ],
+                    ],
                 ],
             ])
             ->toList();

--- a/src/Adapter/Elasticsearch/Mapping.php
+++ b/src/Adapter/Elasticsearch/Mapping.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\Definition\Aggregate as Definition;
+use Innmind\Immutable\Sequence;
+
+/**
+ * @psalm-immutable
+ * @template T of object
+ */
+final class Mapping
+{
+    /** @var Definition<T> */
+    private Definition $definition;
+    private MapType $mapType;
+
+    /**
+     * @param Definition<T> $definition
+     */
+    private function __construct(Definition $definition)
+    {
+        $this->definition = $definition;
+        $this->mapType = MapType::new();
+    }
+
+    public function __invoke(): array
+    {
+        $properties = $this->properties($this->definition->properties());
+        $entities = $this
+            ->definition
+            ->entities()
+            ->map(fn($entity) => [
+                $entity->name() => [
+                    'properties' => $this->properties($entity->properties()),
+                ],
+            ])
+            ->toList();
+        $optionals = $this
+            ->definition
+            ->optionals()
+            ->map(fn($optional) => [
+                $optional->name() => [
+                    'properties' => $this->properties($optional->properties()),
+                ],
+            ])
+            ->toList();
+        $collections = $this
+            ->definition
+            ->collections()
+            ->map(fn($optional) => [
+                $optional->name() => [
+                    'type' => 'nested',
+                    'properties' => $this->properties($optional->properties()),
+                ],
+            ])
+            ->toList();
+
+        return ['properties' => \array_merge(
+            [$this->definition->id()->property() => [
+                'type' => 'keyword',
+                'index' => false,
+            ]],
+            $properties,
+            ...$entities,
+            ...$optionals,
+            ...$collections,
+        )];
+    }
+
+    /**
+     * @psalm-pure
+     * @template A of object
+     *
+     * @param Definition<A> $definition
+     *
+     * @return self<A>
+     */
+    public static function of(Definition $definition): self
+    {
+        return new self($definition);
+    }
+
+    /**
+     * @param Sequence<Definition\Property> $properties
+     */
+    private function properties(Sequence $properties): array
+    {
+        return \array_merge(
+            ...$properties
+                ->map(fn($property) => [
+                    $property->name() => ($this->mapType)($property->type()),
+                ])
+                ->toList(),
+        );
+    }
+}

--- a/src/Adapter/Elasticsearch/Mapping.php
+++ b/src/Adapter/Elasticsearch/Mapping.php
@@ -8,28 +8,20 @@ use Innmind\Immutable\Sequence;
 
 /**
  * @psalm-immutable
- * @template T of object
  */
 final class Mapping
 {
-    /** @var Definition<T> */
-    private Definition $definition;
     private MapType $mapType;
 
-    /**
-     * @param Definition<T> $definition
-     */
-    private function __construct(Definition $definition)
+    private function __construct()
     {
-        $this->definition = $definition;
         $this->mapType = MapType::new();
     }
 
-    public function __invoke(): array
+    public function __invoke(Definition $definition): array
     {
-        $properties = $this->properties($this->definition->properties());
-        $entities = $this
-            ->definition
+        $properties = $this->properties($definition->properties());
+        $entities = $definition
             ->entities()
             ->map(fn($entity) => [
                 $entity->name() => [
@@ -37,8 +29,7 @@ final class Mapping
                 ],
             ])
             ->toList();
-        $optionals = $this
-            ->definition
+        $optionals = $definition
             ->optionals()
             ->map(fn($optional) => [
                 $optional->name() => [
@@ -46,8 +37,7 @@ final class Mapping
                 ],
             ])
             ->toList();
-        $collections = $this
-            ->definition
+        $collections = $definition
             ->collections()
             ->map(fn($optional) => [
                 $optional->name() => [
@@ -58,7 +48,7 @@ final class Mapping
             ->toList();
 
         return ['properties' => \array_merge(
-            [$this->definition->id()->property() => [
+            [$definition->id()->property() => [
                 'type' => 'keyword',
                 'index' => false,
             ]],
@@ -71,15 +61,10 @@ final class Mapping
 
     /**
      * @psalm-pure
-     * @template A of object
-     *
-     * @param Definition<A> $definition
-     *
-     * @return self<A>
      */
-    public static function of(Definition $definition): self
+    public static function new(): self
     {
-        return new self($definition);
+        return new self;
     }
 
     /**

--- a/src/Adapter/Elasticsearch/Query.php
+++ b/src/Adapter/Elasticsearch/Query.php
@@ -1,0 +1,206 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\Specification\{
+    Entity,
+    Child,
+};
+use Innmind\Specification\{
+    Specification,
+    Composite,
+    Operator,
+    Not,
+    Comparator,
+    Sign,
+};
+
+/**
+ * @internal
+ * @psalm-immutable
+ */
+final class Query
+{
+    private function __construct()
+    {
+    }
+
+    public function __invoke(Specification $specification): array
+    {
+        if ($specification instanceof Entity) {
+            return $this->visit($specification, $specification->entity().'.');
+        }
+
+        if ($specification instanceof Child) {
+            return [
+                'nested' => $specification->collection(),
+                'query' => $this->visit(
+                    $specification->specification(),
+                    $specification->collection().'.data.',
+                ),
+            ];
+        }
+
+        return $this->visit($specification);
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function new(): self
+    {
+        return new self;
+    }
+
+    private function visit(Specification $specification, string $prefix = ''): array
+    {
+        if ($specification instanceof Composite) {
+            $left = $this->visit($specification->left(), $prefix);
+            $right = $this->visit($specification->right(), $prefix);
+
+            return match ($specification->operator()) {
+                Operator::and => $this->and($left, $right),
+                Operator::or => $this->or($left, $right),
+            };
+        }
+
+        if ($specification instanceof Not) {
+            return $this->not($this->visit($specification->specification(), $prefix));
+        }
+
+        if ($specification instanceof Comparator) {
+            return $this->compare($specification, $prefix);
+        }
+
+        $class = $specification::class;
+
+        throw new \LogicException("Unsupported specification '$class'");
+    }
+
+    private function and(array $left, array $right): array
+    {
+        return [
+            'bool' => [
+                'must' => [$left, $right],
+            ],
+        ];
+    }
+
+    private function or(array $left, array $right): array
+    {
+        return [
+            'bool' => [
+                'should' => [$left, $right],
+            ],
+        ];
+    }
+
+    private function not(array $query): array
+    {
+        return [
+            'bool' => [
+                'must_not' => [$query],
+            ],
+        ];
+    }
+
+    private function compare(Comparator $specification, string $prefix): array
+    {
+        $property = $prefix.$specification->property();
+
+        // TODO adapt (in)equality and in search type based on the property type
+        // being a keyword or not from the mapping
+        return match ($specification->sign()) {
+            Sign::equality => [
+                'match_phrase' => [
+                    $property => [
+                        'query' => $specification->value(),
+                    ],
+                ],
+            ],
+            Sign::inequality => [
+                'bool' => [
+                    'must_not' => [[
+                        'match_phrase' => [
+                            $property => [
+                                'query' => $specification->value(),
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+            Sign::lessThan => [
+                'range' => [
+                    $property => [
+                        'lt' => $specification->value(),
+                    ],
+                ],
+            ],
+            Sign::moreThan => [
+                'range' => [
+                    $property => [
+                        'gt' => $specification->value(),
+                    ],
+                ],
+            ],
+            Sign::lessThanOrEqual => [
+                'range' => [
+                    $property => [
+                        'lte' => $specification->value(),
+                    ],
+                ],
+            ],
+            Sign::moreThanOrEqual => [
+                'range' => [
+                    $property => [
+                        'gte' => $specification->value(),
+                    ],
+                ],
+            ],
+            Sign::isNull => [
+                'bool' => [
+                    'must_not' => [[
+                        'exists' => [
+                            'field' => $property,
+                        ],
+                    ]],
+                ],
+            ],
+            Sign::isNotNull => [
+                'exists' => [
+                    'field' => $property,
+                ],
+            ],
+            Sign::startsWith => [
+                'wildcard' => [
+                    $property => [
+                        'value' => "{$specification->value()}*",
+                        'case_insensitive' => true, // to match the SQL behaviour
+                    ],
+                ],
+            ],
+            Sign::endsWith => [
+                'wildcard' => [
+                    $property => [
+                        'value' => "*{$specification->value()}",
+                        'case_insensitive' => true, // to match the SQL behaviour
+                    ],
+                ],
+            ],
+            Sign::contains => [
+                'match_phrase_prefix' => [
+                    $property => [
+                        'query' => $specification->value(),
+                    ],
+                ],
+            ],
+            Sign::in => [
+                'terms' => [
+                    $property => $specification->value(),
+                ],
+            ],
+        };
+    }
+}

--- a/src/Adapter/Elasticsearch/Refresh.php
+++ b/src/Adapter/Elasticsearch/Refresh.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Innmind\HttpTransport\Transport;
+use Innmind\Http\Request;
+use Innmind\Url\Query;
+use Innmind\Immutable\{
+    Either,
+    Str,
+};
+
+final class Refresh implements Transport
+{
+    private Transport $transport;
+
+    private function __construct(Transport $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    public function __invoke(Request $request): Either
+    {
+        if (
+            !$request->method()->safe() &&
+            Str::of($request->url()->path()->toString())->matches('~[a-zA-Z0-9]{8}(-[a-zA-Z0-9]{4}){3}-[a-zA-Z0-9]{12}$~')
+        ) {
+            $request = Request::of(
+                $request->url()->withQuery(Query::of('refresh=true')),
+                $request->method(),
+                $request->protocolVersion(),
+                $request->headers(),
+                $request->body(),
+            );
+        }
+
+        return ($this->transport)($request);
+    }
+
+    public static function of(Transport $transport): self
+    {
+        return new self($transport);
+    }
+}

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -113,7 +113,7 @@ final class Repository implements RepositoryInterface
                     ))
                     ->path(),
             ),
-            Method::get,
+            Method::head,
             ProtocolVersion::v11,
         ))->match(
             static fn() => true,

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\{
+    Adapter\Repository as RepositoryInterface,
+    Definition\Aggregate as Definition,
+    Raw\Aggregate,
+    Raw\Diff,
+    Sort,
+};
+use Innmind\HttpTransport\Transport;
+use Innmind\UrlTemplate\Template;
+use Innmind\Url\Url;
+use Innmind\Specification\Specification;
+use Innmind\Immutable\{
+    Sequence,
+    Maybe,
+};
+
+/**
+ * @internal
+ * @template T of object
+ * @implements RepositoryInterface<T>
+ */
+final class Repository implements RepositoryInterface
+{
+    private Transport $transport;
+    private Transaction $transaction;
+    /** @var Definition<T> */
+    private Definition $definition;
+    private Url $url;
+    private Template $template;
+
+    /**
+     * @param Definition<T> $definition
+     */
+    private function __construct(
+        Transport $transport,
+        Transaction $transaction,
+        Definition $definition,
+        Url $url,
+    ) {
+        $this->transport = $transport;
+        $this->transaction = $transaction;
+        $this->definition = $definition;
+        $this->url = $url;
+        $index = $definition->name();
+        /** @psalm-suppress ArgumentTypeCoercion */
+        $this->template = Template::of("/$index{/action,id}");
+    }
+
+    /**
+     * @internal
+     * @template A of object
+     *
+     * @param Definition<A> $definition
+     *
+     * @return self<A>
+     */
+    public static function of(
+        Transport $transport,
+        Transaction $transaction,
+        Definition $definition,
+        Url $url,
+    ): self {
+        return new self($transport, $transaction, $definition, $url);
+    }
+
+    public function get(Aggregate\Id $id): Maybe
+    {
+        /** @var Maybe<Aggregate> */
+        return Maybe::nothing();
+    }
+
+    public function contains(Aggregate\Id $id): bool
+    {
+        return false;
+    }
+
+    public function add(Aggregate $data): void
+    {
+    }
+
+    public function update(Diff $data): void
+    {
+    }
+
+    public function remove(Aggregate\Id $id): void
+    {
+    }
+
+    public function fetch(
+        ?Specification $specification,
+        null|Sort\Property|Sort\Entity $sort,
+        ?int $drop,
+        ?int $take,
+    ): Sequence {
+        return Sequence::of();
+    }
+
+    public function size(Specification $specification = null): int
+    {
+        return 0;
+    }
+
+    public function any(Specification $specification = null): bool
+    {
+        return false;
+    }
+}

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -86,7 +86,22 @@ final class Repository implements RepositoryInterface
 
     public function contains(Aggregate\Id $id): bool
     {
-        return false;
+        return ($this->http)(Request::of(
+            $this->url->withPath(
+                $this
+                    ->path
+                    ->expand(Map::of(
+                        ['action', '_doc'],
+                        ['id', $id->value()],
+                    ))
+                    ->path(),
+            ),
+            Method::get,
+            ProtocolVersion::v11,
+        ))->match(
+            static fn() => true,
+            static fn() => false,
+        );
     }
 
     public function add(Aggregate $data): void

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -250,7 +250,9 @@ final class Repository implements RepositoryInterface
 
     public function any(Specification $specification = null): bool
     {
-        return false;
+        return !$this
+            ->fetch($specification, null, null, 1)
+            ->empty();
     }
 
     /**

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -74,7 +74,7 @@ final class Repository implements RepositoryInterface
         $this->definition = $definition;
         $this->encode = Encode::new();
         $this->decode = Decode::of($definition);
-        $this->query = Query::new();
+        $this->query = Query::new(Mapping::new(), $definition);
         /**
          * @psalm-suppress MixedInferredReturnType
          * @psalm-suppress MixedArrayAccess

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -46,7 +46,6 @@ use Innmind\Immutable\{
 final class Repository implements RepositoryInterface
 {
     private Transport $http;
-    private Transaction $transaction;
     /** @var Definition<T> */
     private Definition $definition;
     private Encode $encode;
@@ -65,12 +64,10 @@ final class Repository implements RepositoryInterface
      */
     private function __construct(
         Transport $http,
-        Transaction $transaction,
         Definition $definition,
         Url $url,
     ) {
         $this->http = $http;
-        $this->transaction = $transaction;
         $this->definition = $definition;
         $this->encode = Encode::new();
         $this->decode = Decode::of($definition);
@@ -131,11 +128,10 @@ final class Repository implements RepositoryInterface
      */
     public static function of(
         Transport $transport,
-        Transaction $transaction,
         Definition $definition,
         Url $url,
     ): self {
-        return new self($transport, $transaction, $definition, $url);
+        return new self($transport, $definition, $url);
     }
 
     public function get(Aggregate\Id $id): Maybe

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -155,6 +155,14 @@ final class Repository implements RepositoryInterface
 
     public function remove(Aggregate\Id $id): void
     {
+        $_ = ($this->http)(Request::of(
+            $this->url('_doc', $id->value()),
+            Method::delete,
+            ProtocolVersion::v11,
+        ))->match(
+            static fn() => null,
+            static fn() => null,
+        );
     }
 
     public function fetch(

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -181,6 +181,18 @@ final class Repository implements RepositoryInterface
 
     public function update(Diff $data): void
     {
+        $_ = ($this->http)(Request::of(
+            $this->url('_update', $data->id()->value()),
+            Method::post,
+            ProtocolVersion::v11,
+            Headers::of(
+                ContentType::of('application', 'json'),
+            ),
+            ($this->encode)($data),
+        ))->match(
+            static fn() => null,
+            static fn() => throw new \RuntimeException('Unable to update the aggregate'),
+        );
     }
 
     public function remove(Aggregate\Id $id): void

--- a/src/Adapter/Elasticsearch/Transaction.php
+++ b/src/Adapter/Elasticsearch/Transaction.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Elasticsearch;
+
+use Formal\ORM\Adapter\Transaction as TransactionInterface;
+
+/**
+ * @internal
+ */
+final class Transaction implements TransactionInterface
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @internal
+     */
+    public static function of(): self
+    {
+        return new self;
+    }
+
+    public function start(): void
+    {
+    }
+
+    /**
+     * @template R
+     *
+     * @return callable(R): R
+     */
+    public function commit(): callable
+    {
+        return static function(mixed $value) {
+            return $value;
+        };
+    }
+
+    /**
+     * @template R
+     *
+     * @return callable(R): R
+     */
+    public function rollback(): callable
+    {
+        return static function(mixed $value) {
+            return $value;
+        };
+    }
+}

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -81,19 +81,19 @@ final class CollectionTable
         return new self($definition, $main);
     }
 
-    public function primaryKey(): Table\Column
+    public function primaryKey(): Column
     {
-        return Table\Column::of(
-            Table\Column\Name::of('entityReference'),
-            Table\Column\Type::varchar(36)->comment('UUID'),
+        return Column::of(
+            Column\Name::of('entityReference'),
+            Column\Type::varchar(36)->comment('UUID'),
         );
     }
 
-    public function foreignKey(): Table\Column
+    public function foreignKey(): Column
     {
-        return Table\Column::of(
-            Table\Column\Name::of('aggregateId'),
-            Table\Column\Type::varchar(36)->comment('UUID'),
+        return Column::of(
+            Column\Name::of('aggregateId'),
+            Column\Type::varchar(36)->comment('UUID'),
         );
     }
 
@@ -105,8 +105,8 @@ final class CollectionTable
         return $this
             ->definition
             ->properties()
-            ->map(static fn($property) => Table\Column::of(
-                Table\Column\Name::of($property->name()),
+            ->map(static fn($property) => Column::of(
+                Column\Name::of($property->name()),
                 $mapType($property->type()),
             ));
     }

--- a/src/Adapter/SQL/EntityTable.php
+++ b/src/Adapter/SQL/EntityTable.php
@@ -68,11 +68,11 @@ final class EntityTable
         return new self($definition, $main);
     }
 
-    public function primaryKey(): Table\Column
+    public function primaryKey(): Column
     {
-        return Table\Column::of(
-            Table\Column\Name::of('aggregateId'),
-            Table\Column\Type::varchar(36)->comment('UUID'),
+        return Column::of(
+            Column\Name::of('aggregateId'),
+            Column\Type::varchar(36)->comment('UUID'),
         );
     }
 
@@ -84,8 +84,8 @@ final class EntityTable
         return $this
             ->definition
             ->properties()
-            ->map(static fn($property) => Table\Column::of(
-                Table\Column\Name::of($property->name()),
+            ->map(static fn($property) => Column::of(
+                Column\Name::of($property->name()),
                 $mapType($property->type()),
             ));
     }

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -151,11 +151,11 @@ final class MainTable
         return new self($definition);
     }
 
-    public function primaryKey(): Table\Column
+    public function primaryKey(): Column
     {
-        return Table\Column::of(
-            Table\Column\Name::of($this->definition->id()->property()),
-            Table\Column\Type::varchar(36)->comment('UUID'),
+        return Column::of(
+            Column\Name::of($this->definition->id()->property()),
+            Column\Type::varchar(36)->comment('UUID'),
         );
     }
 
@@ -167,8 +167,8 @@ final class MainTable
         return $this
             ->definition
             ->properties()
-            ->map(static fn($property) => Table\Column::of(
-                Table\Column\Name::of($property->name()),
+            ->map(static fn($property) => Column::of(
+                Column\Name::of($property->name()),
                 $mapType($property->type()),
             ));
     }

--- a/src/Adapter/SQL/OptionalTable.php
+++ b/src/Adapter/SQL/OptionalTable.php
@@ -73,11 +73,11 @@ final class OptionalTable
         return new self($definition, $main);
     }
 
-    public function primaryKey(): Table\Column
+    public function primaryKey(): Column
     {
-        return Table\Column::of(
-            Table\Column\Name::of('aggregateId'),
-            Table\Column\Type::varchar(36)->comment('UUID'),
+        return Column::of(
+            Column\Name::of('aggregateId'),
+            Column\Type::varchar(36)->comment('UUID'),
         );
     }
 
@@ -89,8 +89,8 @@ final class OptionalTable
         return $this
             ->definition
             ->properties()
-            ->map(static fn($property) => Table\Column::of(
-                Table\Column\Name::of($property->name()),
+            ->map(static fn($property) => Column::of(
+                Column\Name::of($property->name()),
                 $mapType($property->type()),
             ));
     }

--- a/src/Matching.php
+++ b/src/Matching.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 namespace Formal\ORM;
 
 use Formal\ORM\{
-    Adapter,
-    Repository,
     Sort as SortedBy,
     Repository\Loaded,
     Repository\Denormalize,

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Formal\ORM;
 
 use Formal\ORM\{
-    Adapter,
     Definition\Aggregate,
     Repository\Loaded,
     Repository\Normalize,

--- a/src/Sort/Entity.php
+++ b/src/Sort/Entity.php
@@ -5,7 +5,6 @@ namespace Formal\ORM\Sort;
 
 use Formal\ORM\{
     Sort,
-    Sort\Property,
 };
 
 /**


### PR DESCRIPTION
## Request

Closes #2 

## Implementation

- Adds the `Formal\ORM\Adapter\Elasticsearch` adapter
- The sort properties have been modified to use a new `sortableName` property on the `User` that is typed as `keyword` in Elasticsearch
  - Elasticsearch can't sort documents on a `text` field

## Notes 

- The adapter is not tested against Elasticsearch 8 as it has a security layer that I didn't find how to disable yet
- The adapter doesn't support the transactions as Elasticsearch has no such concept. It may be emulated but it would add too much complexity.
- The SQL adapter has been modified due to an update to the code style fixer