### PR TITLE
Fix non detected id property in entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Properties named `id` are now parsed correctly in entities
+
 ## 2.0.0 - 2024-02-25
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "formal/access-layer": "~2.15",
         "innmind/http-transport": "~7.2",
         "innmind/url-template": "~3.1",
-        "innmind/validation": "^1.1.1"
+        "innmind/validation": "~1.4"
     },
     "autoload": {
         "psr-4": {

--- a/fixtures/User/Address.php
+++ b/fixtures/User/Address.php
@@ -13,6 +13,7 @@ final class Address
      * the field being sorted on to be a keyword
      */
     private Sortable $sortable;
+    private ?int $id = null;
 
     private function __construct(string $value)
     {

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -44,12 +44,18 @@ return static function() {
                                 'value' => [
                                     'type' => 'text',
                                 ],
+                                'id' => [
+                                    'type' => 'long',
+                                ],
                             ],
                         ],
                         'billingAddress' => [
                             'properties' => [
                                 'value' => [
                                     'type' => 'text',
+                                ],
+                                'id' => [
+                                    'type' => 'long',
                                 ],
                             ],
                         ],
@@ -58,6 +64,9 @@ return static function() {
                             'properties' => [
                                 'value' => [
                                     'type' => 'text',
+                                ],
+                                'id' => [
+                                    'type' => 'long',
                                 ],
                             ],
                         ],

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -31,13 +31,13 @@ return static function() {
                     CREATE TABLE  `user` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `createdAt` varchar(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_mainAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
+                    CREATE TABLE  `user_mainAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_billingAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
+                    CREATE TABLE  `user_billingAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_addresses` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    CREATE TABLE  `user_addresses` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
                     SQL,
                     <<<SQL
                     CREATE TABLE  `user_roles` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `name` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_roles` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)

--- a/src/Adapter/Elasticsearch/Decode.php
+++ b/src/Adapter/Elasticsearch/Decode.php
@@ -185,8 +185,7 @@ final class Decode
     private static function collection(Definition\Collection $collection): Constraint
     {
         /** @psalm-suppress MixedArgument Due to the array keys */
-        return Is::array()
-            ->and(Is::list())
+        return Is::list()
             ->and(Each::of(
                 self::properties($collection->properties())->map(
                     Aggregate\Collection\Entity::of(...),

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -100,8 +100,7 @@ final class Repository implements RepositoryInterface
                 'hits',
                 Is::array()->and(Shape::of(
                     'hits',
-                    Is::array()
-                        ->and(Is::list())
+                    Is::list()
                         ->and(Each::of(Shape::of(
                             '_source',
                             Is::array(),

--- a/src/Definition/Aggregate/Parsing.php
+++ b/src/Definition/Aggregate/Parsing.php
@@ -215,9 +215,13 @@ final class Parsing
         string $class,
         ReflectionProperty $property,
         Types $types,
+        bool $allowIdAsName = false,
     ): Maybe {
         return Maybe::just($property)
-            ->exclude(static fn($property) => $property->name() === 'id')
+            ->exclude(static fn($property) => match ($allowIdAsName) {
+                true => false,
+                false => $property->name() === 'id',
+            })
             ->flatMap(static fn($property) => $types(
                 $property->type()->type(),
                 $property
@@ -265,6 +269,7 @@ final class Parsing
                                 $property->type()->toString(),
                                 $innerProperty,
                                 $types,
+                                true,
                             )
                             ->toSequence(),
                     ),
@@ -305,6 +310,7 @@ final class Parsing
                                         $property->type()->toString(),
                                         $innerProperty,
                                         $types,
+                                        true,
                                     )
                                     ->toSequence(),
                             ),
@@ -351,6 +357,7 @@ final class Parsing
                                             $property->type()->toString(),
                                             $innerProperty,
                                             $types,
+                                            true,
                                         )
                                         ->toSequence(),
                                 ),


### PR DESCRIPTION
## Problem

If an entity (required, optional or in collections) has a property named `id` then the orm doesn't detect it.

## Solution

Do not apply the exclusion on the `id` name when parsing entities properties. (The exclusion only needs to happen on the aggregate)

## Note

The update to `innmind/validation:~1.4` is needed to solve psalm errors