### PR TITLE
Do not re-persist a collection that has not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- When a `Set` is modified in an aggregate but the resulting `Set` contains the same values the orm no longer re-persist the whole collection
+
 ## 2.1.0 - 2024-06-02
 
 ### Added

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -134,9 +134,9 @@ final class Diff
                 ))
                 ->toSequence(),
         );
-        // The extra filter applied allows to to re-persist the whole Set when
-        // nothing changed inside. This can happen if a user applies a map or
-        // a filter on the original Set but doesn't modify anything.
+        // The exclude allows to not re-persist the whole Set when nothing
+        // changed inside. This can happen if a user applies a map or a
+        // filter on the original Set but doesn't modify anything.
         /**
          * @psalm-suppress MixedArgument
          * @psalm-suppress MixedMethodCall

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -140,6 +140,8 @@ final class Diff
         /**
          * @psalm-suppress MixedArgument
          * @psalm-suppress MixedMethodCall
+         * @psalm-suppress MixedInferredReturnType
+         * @psalm-suppress MixedReturnStatement
          */
         $collections = $diff->flatMap(
             fn($value) => $this

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -134,11 +134,18 @@ final class Diff
                 ))
                 ->toSequence(),
         );
-        /** @psalm-suppress MixedArgument */
+        // The extra filter applied allows to to re-persist the whole Set when
+        // nothing changed inside. This can happen if a user applies a map or
+        // a filter on the original Set but doesn't modify anything.
+        /**
+         * @psalm-suppress MixedArgument
+         * @psalm-suppress MixedMethodCall
+         */
         $collections = $diff->flatMap(
             fn($value) => $this
                 ->normalizeCollection
                 ->get($value->name())
+                ->exclude(static fn(): bool => $value->now()->equals($value->then()))
                 ->map(static fn($normalize) => $normalize($value->now()))
                 ->toSequence(),
         );


### PR DESCRIPTION
## Problem

If an aggregates has a `Set` property and tries to update its values but the operation ends up not changing the values, then the ORM still re-persist the whole collection.

## Solution

Verify that the new `Set` is not equal to the old one.