### PR TITLE
Mass removal of aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Formal\ORM\Adapter\Repository\MassRemoval`
+
 ### Changed
 
 - You can now pass a `Specification` to `Repository::remove()` to remove multiple aggregates at once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- You can now pass a `Specification` to `Repository::remove()` to remove multiple aggregates at once
 - When a `Set` is modified in an aggregate but the resulting `Set` contains the same values the orm no longer re-persist the whole collection
 
 ## 2.1.0 - 2024-06-02

--- a/documentation/use_cases/remove_aggregate.md
+++ b/documentation/use_cases/remove_aggregate.md
@@ -13,3 +13,17 @@ $either = $manager->transactional(
 ```
 
 In the case the id you want to remove doesn't exist it will do nothing.
+
+## Remove multiple aggregates at once
+
+You can remove multiple aggregates at once via a `Specification`. You can use the same specifications as the once to [fetch aggregates](retrieve_aggregates.md#filter-the-aggregates-you-need-to-fetch).
+
+```php
+$manager->transactional(
+    static fn() => Either::right(
+        $manager
+            ->repository(User::class)
+            ->remove(Username::of('alice')->or(Username::of('bob'))),
+    ),
+);
+```

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -36,6 +36,7 @@ final class Properties
             ContainsAggregate::class,
             RemoveUnknownAggregateDoesNothing::class,
             RemoveAggregate::class,
+            RemoveSpecification::class,
             Size::class,
             SizeWithSpecification::class,
             Any::class,

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -100,6 +100,7 @@ final class Properties
             ContainsAggregate::class,
             RemoveUnknownAggregateDoesNothing::class,
             RemoveAggregate::class,
+            RemoveSpecification::class,
             Size::class,
             SizeWithSpecification::class,
             Any::class,

--- a/properties/RemoveSpecification.php
+++ b/properties/RemoveSpecification.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types = 1);
+
+namespace Properties\Formal\ORM;
+
+use Formal\ORM\{
+    Manager,
+    Id,
+};
+use Fixtures\Formal\ORM\{
+    User,
+    Username,
+};
+use Innmind\Specification\Sign;
+use Innmind\Immutable\Str;
+use Innmind\BlackBox\{
+    Set,
+    Property,
+    Runner\Assert,
+};
+use Innmind\Immutable\Either;
+use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
+
+/**
+ * @implements Property<Manager>
+ */
+final class RemoveSpecification implements Property
+{
+    private $createdAt;
+    private string $name1;
+    private string $name2;
+
+    private function __construct(
+        $createdAt,
+        array $names,
+    ) {
+        $this->createdAt = $createdAt;
+        [$this->name1, $this->name2] = $names;
+    }
+
+    public static function any(): Set
+    {
+        return Set\Composite::immutable(
+            static fn(...$args) => new self(...$args),
+            PointInTime::any(),
+            Set\MutuallyExclusive::of(
+                Set\Strings::madeOf(Set\Chars::alphanumerical())->between(10, 100),
+                Set\Strings::madeOf(Set\Chars::alphanumerical())->between(10, 100),
+            ),
+        );
+    }
+
+    public function applicableTo(object $manager): bool
+    {
+        return true;
+    }
+
+    public function ensureHeldBy(Assert $assert, object $manager): object
+    {
+        $user1 = User::new($this->createdAt, $this->name1);
+        $user2 = User::new($this->createdAt, $this->name2);
+
+        $repository = $manager->repository(User::class);
+        $manager->transactional(
+            static function() use ($repository, $user1, $user2) {
+                $repository->put($user1);
+                $repository->put($user2);
+
+                return Either::right(null);
+            },
+        );
+        $user1Id = $user1->id()->toString();
+        $user2Id = $user2->id()->toString();
+        unset($user1);
+        unset($user2);
+
+        $manager->transactional(
+            function() use ($repository) {
+                $repository->remove(Username::of(
+                    Sign::equality,
+                    Str::of($this->name1),
+                ));
+
+                return Either::right(null);
+            },
+        );
+
+        $assert->false($repository->contains(Id::of(User::class, $user1Id)));
+        $assert->true($repository->contains(Id::of(User::class, $user2Id)));
+
+        return $manager;
+    }
+}

--- a/src/Adapter/Elasticsearch/Refresh.php
+++ b/src/Adapter/Elasticsearch/Refresh.php
@@ -22,9 +22,14 @@ final class Refresh implements Transport
 
     public function __invoke(Request $request): Either
     {
+        $path = Str::of($request->url()->path()->toString());
+
         if (
             !$request->method()->safe() &&
-            Str::of($request->url()->path()->toString())->matches('~[a-zA-Z0-9]{8}(-[a-zA-Z0-9]{4}){3}-[a-zA-Z0-9]{12}$~')
+            (
+                $path->matches('~[a-zA-Z0-9]{8}(-[a-zA-Z0-9]{4}){3}-[a-zA-Z0-9]{12}$~') ||
+                $path->endsWith('_delete_by_query')
+            )
         ) {
             $request = Request::of(
                 $request->url()->withQuery(Query::of('refresh=true')),

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -43,7 +43,7 @@ use Innmind\Immutable\{
  * @template T of object
  * @implements RepositoryInterface<T>
  */
-final class Repository implements RepositoryInterface
+final class Repository implements RepositoryInterface, RepositoryInterface\MassRemoval
 {
     private Transport $http;
     /** @var Definition<T> */
@@ -199,6 +199,24 @@ final class Repository implements RepositoryInterface
         ))->match(
             static fn() => null,
             static fn() => null,
+        );
+    }
+
+    public function removeAll(Specification $specification): void
+    {
+        $_ = ($this->http)(Request::of(
+            $this->url('_delete_by_query'),
+            Method::post,
+            ProtocolVersion::v11,
+            Headers::of(
+                ContentType::of('application', 'json'),
+            ),
+            Content::ofString(Json::encode([
+                'query' => ($this->query)($specification),
+            ])),
+        ))->match(
+            static fn() => null,
+            static fn() => throw new \RuntimeException('Unable to remove multiple aggregates'),
         );
     }
 

--- a/src/Adapter/Repository/MassRemoval.php
+++ b/src/Adapter/Repository/MassRemoval.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Adapter\Repository;
+
+use Innmind\Specification\Specification;
+
+/**
+ * This interface will be merged with the Repository one in the next major version
+ */
+interface MassRemoval
+{
+    public function removeAll(Specification $specification): void;
+}

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -268,9 +268,12 @@ final class MainTable
     /**
      * @internal
      */
-    public function delete(): Delete
+    public function delete(Specification $specification = null): Delete
     {
-        return $this->delete;
+        return match ($specification) {
+            null => $this->delete,
+            default => $this->delete->where($this->where($specification)),
+        };
     }
 
     /**

--- a/src/Adapter/SQL/Repository.php
+++ b/src/Adapter/SQL/Repository.php
@@ -30,7 +30,7 @@ use Innmind\Immutable\{
  * @template T of object
  * @implements RepositoryInterface<T>
  */
-final class Repository implements RepositoryInterface
+final class Repository implements RepositoryInterface, RepositoryInterface\MassRemoval
 {
     private Connection $connection;
     /** @var Definition<T> */
@@ -121,6 +121,13 @@ final class Repository implements RepositoryInterface
                 ->mainTable
                 ->delete()
                 ->where(Property::of($this->idColumn, Sign::equality, $id->value())),
+        );
+    }
+
+    public function removeAll(Specification $specification): void
+    {
+        $_ = ($this->connection)(
+            $this->mainTable->delete($specification),
         );
     }
 


### PR DESCRIPTION
## Request

Let's say you have a blog with a `User` aggregate and a `Comment` aggregate. In each comment there's a reference to a user. 

When you want to remove a user you first need to remove all the associated comments. Currently to do so you need to fetch them all and remove them one by one. This is obviously terribly slow.

There should be a way to remove multiple aggregates at once.

## Solution

- `Repository::remove()` now accepts a `Specification`. This is the same kind of specification as you'd use with `matching`.
- Adds `Formal\ORM\Adapter\Repository\MassRemoval`
- SQL and Elasticsearch are optimized for the mass removal via dedicated queries

## Remark

The filesystem adapter does not implement this new interface to allow to cover the case an adapter doesn't implement this new interface (as it may happen for a third party adapter)
