### PR TITLE
Fix `MatchingOptional` property

### DIFF
--- a/documentation/issues.md
+++ b/documentation/issues.md
@@ -1,0 +1,19 @@
+---
+hide:
+    - navigation
+---
+
+# Known issues
+
+## Elasticsearch
+
+### Searching with `endsWith`
+
+When searching aggregates via a [specification](specifications/index.md) with `Sign::endsWith` you may not always see all the results.
+
+Internally this search uses the [`wildcard` query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html) with the value starting with `*`. As described in the documentation this **SHOULD NOT** be used as it's an expensive query.
+
+If you really need to do this kind of search you could add an extra property on your aggregate with the string being in reversed order from the original one. You can then do a search on this property with `Sign::startsWith` and reversing the string used as argument.
+
+!!! warning ""
+    Bear in mind that `startsWith` also uses the `wildcard` query and may slower that you'd want or even not return the results you'd expect.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
     - Export aggregates as a CSV: use-cases/export.md
     - Import aggregates from a CSV: use-cases/import.md
     - Search an aggregate via Elasticsearch: use-cases/elasticsearch.md
+  - Known issues: issues.md
   - Benchmark: benchmark.md
   - Blog:
     - blog/index.md

--- a/properties/MatchingOptional.php
+++ b/properties/MatchingOptional.php
@@ -114,7 +114,7 @@ final class MatchingOptional implements Property
 
         $found = $repository
             ->matching(Just::of('billingAddress', AddressValue::of(
-                Sign::endsWith,
+                Sign::equality,
                 $this->name1,
             ))->not())
             ->map(static fn($user) => $user->id()->toString())


### PR DESCRIPTION
## Problem

In the CI when this property is run in a sequence of properties it randomly fails.

After investigation the query run is `not(endsWith)` opposed to the `equality` from previous queries in the same property. This is a bad copy/paste from another property, the aimed query was `not(equality)`.

When checking the documentation of Elasticsearch it's indicated that a `wildcard` query starting with `*`, which is what `endsWith` is translated to, is an expensive query that should be avoided.

## Solution

- Fix property to use `not(equality)`
- Add a `Known issues` chapter in the documentation