### PR TITLE
Fix SQL types

### DIFF
--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -28,7 +28,7 @@ return static function() {
             $assert
                 ->expected([
                     <<<SQL
-                    CREATE TABLE  `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` varchar(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE  `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
                     CREATE TABLE  `user_mainAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -28,19 +28,19 @@ return static function() {
             $assert
                 ->expected([
                     <<<SQL
-                    CREATE TABLE  `user` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `createdAt` varchar(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE  `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` varchar(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_mainAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
+                    CREATE TABLE  `user_mainAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_billingAddress` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
+                    CREATE TABLE  `user_billingAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_addresses` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    CREATE TABLE  `user_addresses` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
                     SQL,
                     <<<SQL
-                    CREATE TABLE  `user_roles` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `name` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_roles` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    CREATE TABLE  `user_roles` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `name` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_roles` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
                     SQL,
                 ])
                 ->same($queries);

--- a/src/Adapter/SQL/CollectionTable.php
+++ b/src/Adapter/SQL/CollectionTable.php
@@ -81,7 +81,7 @@ final class CollectionTable
     {
         return Column::of(
             Column\Name::of('aggregateId'),
-            Column\Type::varchar(36)->comment('UUID'),
+            Column\Type::char(36)->comment('UUID'),
         );
     }
 

--- a/src/Adapter/SQL/EntityTable.php
+++ b/src/Adapter/SQL/EntityTable.php
@@ -72,7 +72,7 @@ final class EntityTable
     {
         return Column::of(
             Column\Name::of('aggregateId'),
-            Column\Type::varchar(36)->comment('UUID'),
+            Column\Type::char(36)->comment('UUID'),
         );
     }
 

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -155,7 +155,7 @@ final class MainTable
     {
         return Column::of(
             Column\Name::of($this->definition->id()->property()),
-            Column\Type::varchar(36)->comment('UUID'),
+            Column\Type::char(36)->comment('UUID'),
         );
     }
 

--- a/src/Adapter/SQL/MapType.php
+++ b/src/Adapter/SQL/MapType.php
@@ -23,7 +23,7 @@ final class MapType
             $type instanceof Type\MaybeType => $this($type->inner())->nullable(),
             $type instanceof Type\BoolType => Table\Column\Type::tinyint(1)
                 ->comment('Boolean'),
-            $type instanceof Type\IdType => Table\Column\Type::varchar(36)
+            $type instanceof Type\IdType => Table\Column\Type::char(36)
                 ->comment('UUID'),
             $type instanceof Type\IntType => Table\Column\Type::bigint()
                 ->comment('TODO Adjust the size depending on your use case'),

--- a/src/Adapter/SQL/MapType.php
+++ b/src/Adapter/SQL/MapType.php
@@ -27,7 +27,7 @@ final class MapType
                 ->comment('UUID'),
             $type instanceof Type\IntType => Table\Column\Type::bigint()
                 ->comment('TODO Adjust the size depending on your use case'),
-            $type instanceof Type\PointInTimeType => Table\Column\Type::varchar(32)
+            $type instanceof Type\PointInTimeType => Table\Column\Type::char(32)
                 ->comment('Date with timezone down to the microsecond'),
             default => Table\Column\Type::longtext()
                 ->comment('TODO adjust the type depending on your use case'),

--- a/src/Adapter/SQL/OptionalTable.php
+++ b/src/Adapter/SQL/OptionalTable.php
@@ -82,7 +82,7 @@ final class OptionalTable
     {
         return Column::of(
             Column\Name::of('aggregateId'),
-            Column\Type::varchar(36)->comment('UUID'),
+            Column\Type::char(36)->comment('UUID'),
         );
     }
 


### PR DESCRIPTION
## Problem

Ids and dates are stored in SQL via `varchar` but their data never change in size. So it's useless to tell the database that the data may vary in size.

## Solution

Use `char(36)` for ids and `char(32)` for dates

## Note

Existing projects are not affected by this change.