### PR TITLE
Fix matching optional

### DIFF
--- a/documentation/specifications/custom.md
+++ b/documentation/specifications/custom.md
@@ -134,6 +134,11 @@ Depending of the kind of entity you'd use this like this:
 
     If the aggregate doesn't have an address specified then it won't be matched.
 
+    ??? warning
+        You **MUST NOT** negate a `Just` specification as it may not produce the results you'd expect. However you can negate the specification inside the `Just`.
+
+        This is due to a behaviour inconsistency in [Elasticsearch](../adapters/elasticsearch.md).
+
 === "Entity colleciton"
     ```php
     use Formal\ORM\Specification\Just;

--- a/properties/MatchingOptional.php
+++ b/properties/MatchingOptional.php
@@ -116,7 +116,7 @@ final class MatchingOptional implements Property
             ->matching(Just::of('billingAddress', AddressValue::of(
                 Sign::equality,
                 $this->name1,
-            ))->not())
+            )->not()))
             ->map(static fn($user) => $user->id()->toString())
             ->toList();
 

--- a/properties/MatchingOptional.php
+++ b/properties/MatchingOptional.php
@@ -129,6 +129,7 @@ final class MatchingOptional implements Property
             ->in($found);
         $assert
             ->expected($user3->id()->toString())
+            ->not()
             ->in($found);
 
         return $manager;

--- a/src/Adapter/Elasticsearch/Query.php
+++ b/src/Adapter/Elasticsearch/Query.php
@@ -98,7 +98,14 @@ final class Query
         }
 
         if ($specification instanceof Just) {
-            return $this->visit($specification->specification(), $specification->optional().'.');
+            return $this->and(
+                [
+                    'exists' => [
+                        'field' => $specification->optional(),
+                    ],
+                ],
+                $this->visit($specification->specification(), $specification->optional().'.'),
+            );
         }
 
         if ($specification instanceof Child) {

--- a/src/Adapter/Elasticsearch/Query.php
+++ b/src/Adapter/Elasticsearch/Query.php
@@ -98,14 +98,7 @@ final class Query
         }
 
         if ($specification instanceof Just) {
-            return $this->and(
-                [
-                    'exists' => [
-                        'field' => $specification->optional(),
-                    ],
-                ],
-                $this->visit($specification->specification(), $specification->optional().'.'),
-            );
+            return $this->visit($specification->specification(), $specification->optional().'.');
         }
 
         if ($specification instanceof Child) {


### PR DESCRIPTION
## Problem

#29 did not entirely fix matching on optional entities for Elasticsearch.

The problem seems to reside on the negation of a `Just` query. But since the error doesn't always manifest, especially outside the CI, it's almost impossible to determine the real problem.

## Solution

- The property has been changed to negate the specification inside the `Just` instead of the `Just` itself
- Enforce the optional entity to exist in the index
- Add warning in the documentation of this bad behaviour