### PR TITLE
Fix `PointInTimeType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Formal\ORM\Definition\Type\PointInTimeType::new()`
+
+### Deprecated
+
+- `Formal\ORM\Definition\Type\PointInTimeType::of()` as it uses a non standard string format. Use `::new()` instead, but don't forget to migrate your data.
+
 ### Fixed
 
 - Psalm was complaining of a missing argument when using `PointInTimeType::of()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Psalm was complaining of a missing argument when using `PointInTimeType::of()`
+
 ## 3.1.0 - 2024-07-26
 
 ### Added

--- a/benchmark/fill_storage.php
+++ b/benchmark/fill_storage.php
@@ -11,6 +11,7 @@ use Formal\ORM\{
     Adapter,
 };
 use Innmind\OperatingSystem\Factory;
+use Innmind\TimeContinuum\PointInTime;
 use Innmind\Url\Url;
 use Innmind\BlackBox\{
     Set,
@@ -18,12 +19,15 @@ use Innmind\BlackBox\{
 };
 use Innmind\Immutable\Either;
 use Fixtures\Formal\ORM\User;
-use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
+use Fixtures\Innmind\TimeContinuum\Earth\PointInTime as FPointInTime;
 
 $os = Factory::build();
 $connection = $os->remote()->sql(Url::of("mysql://root:root@127.0.0.1:3306/example"));
 $aggregates = Aggregates::of(Types::of(
-    Type\PointInTimeType::of($os->clock()),
+    Type\Support::class(
+        PointInTime::class,
+        Type\PointInTimeType::new($os->clock()),
+    ),
 ));
 
 $_ = Adapter\SQL\ShowCreateTable::of($aggregates)(User::class)->foreach($connection);
@@ -33,7 +37,7 @@ $repository = $manager->repository(User::class);
 
 $users = Set\Composite::immutable(
     User::new(...),
-    PointInTime::any(),
+    FPointInTime::any(),
     Set\Strings::madeOf(Set\Chars::alphanumerical())->between(0, 250),
 );
 $users = Set\Randomize::of($users)->take(100_000)->values(Random::default);

--- a/benchmark/load.php
+++ b/benchmark/load.php
@@ -12,11 +12,15 @@ use Formal\ORM\{
 use Innmind\OperatingSystem\Factory;
 use Innmind\Url\Url;
 use Fixtures\Formal\ORM\User;
+use Innmind\TimeContinuum\PointInTime;
 
 $os = Factory::build();
 $connection = $os->remote()->sql(Url::of("mysql://root:root@127.0.0.1:3306/example"));
 $aggregates = Aggregates::of(Types::of(
-    Type\PointInTimeType::of($os->clock()),
+    Type\Support::class(
+        PointInTime::class,
+        Type\PointInTimeType::new($os->clock()),
+    ),
 ));
 
 $manager = Manager::sql($connection, $aggregates);

--- a/documentation/mapping/index.md
+++ b/documentation/mapping/index.md
@@ -33,14 +33,19 @@ By default Formal also supports:
         Manager,
         Definition\Aggregates,
         Definition\Types,
-        Definition\Type\PointInTime,
-    }
+        Definition\Type\Support,
+        Definition\Type\PointInTimeType,
+    };
+    use Innmind\TimeContinuum\PointInTime;
 
     $orm = Manager::of(
         /* any adapter (1) */,
         Aggregates::of(
             Types::of(
-                PointInTimeType::of($os->clock()),
+                Support::class(
+                    PointInTime::class,
+                    PointInTimeType::new($os->clock()),
+                ),
             ),
         ),
     );

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -8,7 +8,10 @@ use Formal\ORM\{
     Definition\Type,
     Definition\Types,
 };
-use Innmind\TimeContinuum\Earth\Clock;
+use Innmind\TimeContinuum\{
+    Earth\Clock,
+    PointInTime,
+};
 use Fixtures\Formal\ORM\User;
 
 return static function() {
@@ -16,7 +19,10 @@ return static function() {
         'Define Elasticsearch index mapping for the User fixture',
         static function($assert) {
             $aggregates = Aggregates::of(Types::of(
-                Type\PointInTimeType::of(new Clock),
+                Type\Support::class(
+                    PointInTime::class,
+                    Type\PointInTimeType::new(new Clock),
+                ),
             ));
 
             $mapping = Mapping::new()($aggregates->get(User::class));

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -9,7 +9,10 @@ use Formal\ORM\{
     Definition\Types,
 };
 use Formal\AccessLayer\Driver;
-use Innmind\TimeContinuum\Earth\Clock;
+use Innmind\TimeContinuum\{
+    Earth\Clock,
+    PointInTime,
+};
 use Fixtures\Formal\ORM\User;
 
 return static function() {
@@ -18,7 +21,10 @@ return static function() {
         static function($assert) {
             $show = ShowCreateTable::of(
                 Aggregates::of(Types::of(
-                    Type\PointInTimeType::of(new Clock),
+                    Type\Support::class(
+                        PointInTime::class,
+                        Type\PointInTimeType::new(new Clock),
+                    ),
                 )),
             );
 
@@ -53,7 +59,10 @@ return static function() {
         static function($assert) {
             $show = ShowCreateTable::of(
                 Aggregates::of(Types::of(
-                    Type\PointInTimeType::of(new Clock),
+                    Type\Support::class(
+                        PointInTime::class,
+                        Type\PointInTimeType::new(new Clock),
+                    ),
                 ))->mapName(static fn($string) => match ($string) {
                     User::class => 'some_user',
                 }),

--- a/proofs/manager.php
+++ b/proofs/manager.php
@@ -85,10 +85,7 @@ return static function() {
         Set\Call::of(static fn() => Manager::filesystem(
             InMemory::emulateFilesystem(),
             Aggregates::of(Types::of(
-                Type\Support::class(
-                    PointInTime::class,
-                    Type\PointInTimeType::new(new Clock),
-                ),
+                Type\PointInTimeType::of(new Clock),
                 SortableType::of(...),
             )),
         )),

--- a/proofs/manager.php
+++ b/proofs/manager.php
@@ -28,7 +28,10 @@ use Formal\AccessLayer\{
 };
 use Innmind\OperatingSystem\Factory;
 use Innmind\Filesystem\Adapter\InMemory;
-use Innmind\TimeContinuum\Earth\Clock;
+use Innmind\TimeContinuum\{
+    Earth\Clock,
+    PointInTime,
+};
 use Innmind\Url\Url;
 use Innmind\Immutable\Either;
 use Innmind\BlackBox\Set;
@@ -82,7 +85,10 @@ return static function() {
         Set\Call::of(static fn() => Manager::filesystem(
             InMemory::emulateFilesystem(),
             Aggregates::of(Types::of(
-                Type\PointInTimeType::of(new Clock),
+                Type\Support::class(
+                    PointInTime::class,
+                    Type\PointInTimeType::new(new Clock),
+                ),
                 SortableType::of(...),
             )),
         )),
@@ -94,7 +100,10 @@ return static function() {
             Set\Call::of(static fn() => Manager::filesystem(
                 InMemory::emulateFilesystem(),
                 Aggregates::of(Types::of(
-                    Type\PointInTimeType::of(new Clock),
+                    Type\Support::class(
+                        PointInTime::class,
+                        Type\PointInTimeType::new(new Clock),
+                    ),
                     SortableType::of(...),
                 )),
             )),
@@ -105,7 +114,10 @@ return static function() {
 
     $os = Factory::build();
     $aggregates = Aggregates::of(Types::of(
-        Type\PointInTimeType::of($os->clock()),
+        Type\Support::class(
+            PointInTime::class,
+            Type\PointInTimeType::new($os->clock()),
+        ),
         SortableType::of(...),
     ));
 

--- a/src/Definition/Type/PointInTimeType.php
+++ b/src/Definition/Type/PointInTimeType.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Formal\ORM\Definition\Type;
 
 use Formal\ORM\Definition\{
+    Contains,
     Type,
     Types,
     Type\PointInTimeType\Format,
@@ -34,7 +35,7 @@ final class PointInTimeType implements Type
     /**
      * @psalm-pure
      *
-     * @return callable(Types, Concrete): Maybe<self>
+     * @return callable(Types, Concrete, ?Contains): Maybe<self>
      */
     public static function of(Clock $clock): callable
     {

--- a/src/Definition/Type/PointInTimeType/Format.php
+++ b/src/Definition/Type/PointInTimeType/Format.php
@@ -17,6 +17,9 @@ final class Format implements FormatInterface
      */
     private string $format = 'Y:m:d\TH:i:s.uP';
 
+    /**
+     * @psalm-pure
+     */
     public static function new(): self
     {
         $self = new self;

--- a/src/Definition/Type/PointInTimeType/Format.php
+++ b/src/Definition/Type/PointInTimeType/Format.php
@@ -10,8 +10,23 @@ use Innmind\TimeContinuum\Format as FormatInterface;
  */
 final class Format implements FormatInterface
 {
+    /**
+     * This is a non standard format (stupid mistake) but is kept as is until
+     * the next major release. The ::new named constructor should be used to
+     * have the correct format (that will be the future default).
+     */
+    private string $format = 'Y:m:d\TH:i:s.uP';
+
+    public static function new(): self
+    {
+        $self = new self;
+        $self->format = 'Y-m-d\TH:i:s.uP';
+
+        return $self;
+    }
+
     public function toString(): string
     {
-        return 'Y:m:d\TH:i:s.uP';
+        return $this->format;
     }
 }


### PR DESCRIPTION
## Problems

- When using `Types::of(PointInTimeType::of($clock))` Psalm complains that `Types` is using an extra argument that's not used by the type (thus not declared)
- The string format used to persist the objects is non standard as it uses `:` to separate the year, month and day

## Solutions

- Add the extra argument in the type declaration (even though it's not used)
- Add `PointInTimeType::new()` that use a standard format (it replaces `:` by `-`)
- Deprecates `PointInTimeType::of()`