### PR TITLE
Fix generating an invalid sql query when no property has changed in a new optional entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Updating an optional entity resulting in no property change no longer raised an exception when stored via SQL
+- Updating an optional entity resulting in no property change no longer raised an exception when stored via SQL nor it generates an invalid document in Elasticsearch
 
 ## 3.1.1 - 2024-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Updating an optional entity resulting in no property change no longer raised an exception when stored via SQL
+
 ## 3.0.0 - 2024-07-14
 
 ### Added

--- a/fixtures/User.php
+++ b/fixtures/User.php
@@ -194,6 +194,23 @@ final class User
         );
     }
 
+    /**
+     * @param callable(User\Address): User\Address $map
+     */
+    public function mapBillingAddress(callable $map): self
+    {
+        return new self(
+            $this->id,
+            $this->createdAt,
+            $this->name,
+            $this->mainAddress,
+            $this->billingAddress->map($map),
+            $this->addresses,
+            $this->role,
+            $this->roles,
+        );
+    }
+
     public function removeBillingAddress(): self
     {
         /** @var Maybe<User\Address> */

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -66,6 +66,7 @@ final class Properties
             IncrementallyAddElementsToACollection::class,
             AddElementToCollections::class,
             ListingAggregatesUseConstantMemory::class,
+            UpdateOptionalWithoutChangingInnerProperties::class,
         ];
     }
 
@@ -128,6 +129,7 @@ final class Properties
             DroppingMoreElementsThanWasTakenReturnsNothing::class,
             AddingOutsideOfTransactionIsNotAllowed::class,
             IncrementallyAddElementsToACollection::class,
+            UpdateOptionalWithoutChangingInnerProperties::class,
         ];
     }
 }

--- a/properties/UpdateOptionalWithoutChangingInnerProperties.php
+++ b/properties/UpdateOptionalWithoutChangingInnerProperties.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types = 1);
+
+namespace Properties\Formal\ORM;
+
+use Formal\ORM\{
+    Manager,
+    Specification\Just,
+};
+use Fixtures\Formal\ORM\{
+    User,
+    AddressValue,
+};
+use Innmind\Specification\Sign;
+use Innmind\BlackBox\{
+    Set,
+    Property,
+    Runner\Assert,
+};
+use Innmind\Immutable\Either;
+use Fixtures\Innmind\TimeContinuum\Earth\PointInTime;
+
+/**
+ * @implements Property<Manager>
+ */
+final class UpdateOptionalWithoutChangingInnerProperties implements Property
+{
+    private $createdAt;
+    private string $name;
+
+    private function __construct(
+        $createdAt,
+        string $name,
+    ) {
+        $this->createdAt = $createdAt;
+        $this->name = $name;
+    }
+
+    public static function any(): Set
+    {
+        return Set\Composite::immutable(
+            static fn(...$args) => new self(...$args),
+            PointInTime::any(),
+            Set\Strings::madeOf(Set\Chars::alphanumerical())->between(10, 100),
+        );
+    }
+
+    public function applicableTo(object $manager): bool
+    {
+        return true;
+    }
+
+    public function ensureHeldBy(Assert $assert, object $manager): object
+    {
+        $user = User::new($this->createdAt)->changeBillingAddress($this->name);
+
+        $repository = $manager->repository(User::class);
+        $manager->transactional(
+            static function() use ($repository, $user) {
+                $repository->put($user);
+
+                return Either::right(null);
+            },
+        );
+
+        $user = $user->mapBillingAddress(static fn($address) => clone $address);
+
+        $assert->not()->throws(
+            static fn() => $manager->transactional(
+                static function() use ($repository, $user) {
+                    $repository->put($user);
+
+                    return Either::right(null);
+                },
+            ),
+        );
+
+        return $manager;
+    }
+}

--- a/properties/UpdateOptionalWithoutChangingInnerProperties.php
+++ b/properties/UpdateOptionalWithoutChangingInnerProperties.php
@@ -3,14 +3,8 @@ declare(strict_types = 1);
 
 namespace Properties\Formal\ORM;
 
-use Formal\ORM\{
-    Manager,
-    Specification\Just,
-};
-use Fixtures\Formal\ORM\{
-    User,
-    AddressValue,
-};
+use Formal\ORM\Manager;
+use Fixtures\Formal\ORM\User;
 use Innmind\Specification\Sign;
 use Innmind\BlackBox\{
     Set,

--- a/properties/UpdateOptionalWithoutChangingInnerProperties.php
+++ b/properties/UpdateOptionalWithoutChangingInnerProperties.php
@@ -5,7 +5,6 @@ namespace Properties\Formal\ORM;
 
 use Formal\ORM\Manager;
 use Fixtures\Formal\ORM\User;
-use Innmind\Specification\Sign;
 use Innmind\BlackBox\{
     Set,
     Property,

--- a/src/Adapter/Elasticsearch/Encode.php
+++ b/src/Adapter/Elasticsearch/Encode.php
@@ -25,12 +25,17 @@ final class Encode
         $properties = $this->properties($data->properties());
         $entities = $data
             ->entities()
+            ->exclude(static fn($entity) => $entity->properties()->empty())
             ->map(fn($entity) => [
                 $entity->name() => $this->properties($entity->properties()),
             ])
             ->toList();
         $optionals = $data
             ->optionals()
+            ->exclude(static fn($optional) => $optional->properties()->match(
+                static fn($properties) => $properties->empty(),
+                static fn() => false, // force setting the property to null below
+            ))
             ->map(fn($optional) => [
                 $optional->name() => $optional->properties()->match(
                     $this->properties(...),

--- a/src/Adapter/SQL/OptionalTable.php
+++ b/src/Adapter/SQL/OptionalTable.php
@@ -170,24 +170,27 @@ final class OptionalTable
         }
 
         return $optional->properties()->match(
-            fn($properties) => Sequence::of(
-                Update::set(
-                    $this->name,
-                    Row::new(
-                        ...$properties
-                            ->map(static fn($property) => Row\Value::of(
-                                Column\Name::of($property->name()),
-                                $property->value(),
-                            ))
-                            ->toList(),
-                    ),
-                )
-                    ->where(PropertySpecification::of(
-                        'aggregateId',
-                        Sign::equality,
-                        $id->value(),
-                    )),
-            ),
+            fn($properties) => match ($properties->empty()) {
+                true => Sequence::of(),
+                false => Sequence::of(
+                    Update::set(
+                        $this->name,
+                        Row::new(
+                            ...$properties
+                                ->map(static fn($property) => Row\Value::of(
+                                    Column\Name::of($property->name()),
+                                    $property->value(),
+                                ))
+                                ->toList(),
+                        ),
+                    )
+                        ->where(PropertySpecification::of(
+                            'aggregateId',
+                            Sign::equality,
+                            $id->value(),
+                        )),
+                ),
+            },
             fn() => Sequence::of(
                 Delete::from($this->name)->where(PropertySpecification::of(
                     'aggregateId',


### PR DESCRIPTION
## Problem

When updating an optional entity if the initial state contains an entity and the new one contains a new entity but all the properties are the same (equivalent to a clone), then it generates an invalid SQL query has no property is trying to be updated.

## Fix

Do not return an update query if the properties to update is empty.

The new property found a similar error in Elasticsearch, hence the modification for this adapter as well. (The difference being that it stores an empty array for the optional and it no longer pass validation when fetching it)

## Note

All other updates already check the properties are not empty. This is mainly an overlook due to the `Maybe` emptiness check done at the same place that lead to forget to check the properties `Sequence`.