### PR TITLE
Add `Has` specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Formal\ORM\Specification\Has`
+
 ### Fixed
 
 - Updating an optional entity resulting in no property change no longer raised an exception when stored via SQL nor it generates an invalid document in Elasticsearch

--- a/documentation/specifications/custom.md
+++ b/documentation/specifications/custom.md
@@ -102,7 +102,7 @@ Depending of the kind of entity you'd use this like this:
     Has::an('address');
     ```
 
-    And if you want to match aggregates that do not have an entity: `Has::an('address')->not()`.
+    And if you want to match aggregates that do not have an entity: `#!php Has::an('address')->not()`.
 
 === "Entity colleciton"
     ```php

--- a/documentation/specifications/custom.md
+++ b/documentation/specifications/custom.md
@@ -94,6 +94,16 @@ Depending of the kind of entity you'd use this like this:
 
         This is due to a behaviour inconsistency in [Elasticsearch](../adapters/elasticsearch.md).
 
+    If you only need to know if an entity exist you can use `Has`:
+
+    ```php
+    use Formal\ORM\Specification\Has;
+
+    Has::an('address');
+    ```
+
+    And if you want to match aggregates that do not have an entity: `Has::an('address')->not()`.
+
 === "Entity colleciton"
     ```php
     use Formal\ORM\Specification\Just;

--- a/documentation/specifications/custom.md
+++ b/documentation/specifications/custom.md
@@ -89,11 +89,6 @@ Depending of the kind of entity you'd use this like this:
 
     If the aggregate doesn't have an address specified then it won't be matched.
 
-    ??? warning
-        You **MUST NOT** negate a `Just` specification as it may not produce the results you'd expect. However you can negate the specification inside the `Just`.
-
-        This is due to a behaviour inconsistency in [Elasticsearch](../adapters/elasticsearch.md).
-
     If you only need to know if an entity exist you can use `Has`:
 
     ```php
@@ -102,7 +97,10 @@ Depending of the kind of entity you'd use this like this:
     Has::an('address');
     ```
 
-    And if you want to match aggregates that do not have an entity: `#!php Has::an('address')->not()`.
+    ??? warning
+        You **MUST NOT** negate a `Just` or a `Has` specification as it may not produce the results you'd expect. However you can negate the specification inside the `Just`.
+
+        This is due to a behaviour inconsistency in [Elasticsearch](../adapters/elasticsearch.md).
 
 === "Entity colleciton"
     ```php

--- a/properties/MatchingOptional.php
+++ b/properties/MatchingOptional.php
@@ -89,7 +89,7 @@ final class MatchingOptional implements Property
             ->in($found);
 
         $found = $repository
-            ->matching(Has::a('billingAddress')->not())
+            ->matching(Has::an('billingAddress')->not()) // use the other named constructor for code coverage
             ->map(static fn($user) => $user->id()->toString())
             ->toList();
 

--- a/properties/MatchingOptional.php
+++ b/properties/MatchingOptional.php
@@ -6,6 +6,7 @@ namespace Properties\Formal\ORM;
 use Formal\ORM\{
     Manager,
     Specification\Just,
+    Specification\Has,
 };
 use Fixtures\Formal\ORM\{
     User,
@@ -70,6 +71,39 @@ final class MatchingOptional implements Property
                 return Either::right(null);
             },
         );
+
+        $found = $repository
+            ->matching(Has::a('billingAddress'))
+            ->map(static fn($user) => $user->id()->toString())
+            ->toList();
+
+        $assert
+            ->expected($user1->id()->toString())
+            ->in($found);
+        $assert
+            ->expected($user2->id()->toString())
+            ->in($found);
+        $assert
+            ->expected($user3->id()->toString())
+            ->not()
+            ->in($found);
+
+        $found = $repository
+            ->matching(Has::a('billingAddress')->not())
+            ->map(static fn($user) => $user->id()->toString())
+            ->toList();
+
+        $assert
+            ->expected($user1->id()->toString())
+            ->not()
+            ->in($found);
+        $assert
+            ->expected($user2->id()->toString())
+            ->not()
+            ->in($found);
+        $assert
+            ->expected($user3->id()->toString())
+            ->in($found);
 
         $found = $repository
             ->matching(Just::of('billingAddress', AddressValue::of(

--- a/properties/MatchingOptional.php
+++ b/properties/MatchingOptional.php
@@ -89,23 +89,6 @@ final class MatchingOptional implements Property
             ->in($found);
 
         $found = $repository
-            ->matching(Has::an('billingAddress')->not()) // use the other named constructor for code coverage
-            ->map(static fn($user) => $user->id()->toString())
-            ->toList();
-
-        $assert
-            ->expected($user1->id()->toString())
-            ->not()
-            ->in($found);
-        $assert
-            ->expected($user2->id()->toString())
-            ->not()
-            ->in($found);
-        $assert
-            ->expected($user3->id()->toString())
-            ->in($found);
-
-        $found = $repository
             ->matching(Just::of('billingAddress', AddressValue::of(
                 Sign::equality,
                 $this->name1,

--- a/src/Adapter/Elasticsearch/Query.php
+++ b/src/Adapter/Elasticsearch/Query.php
@@ -8,6 +8,7 @@ use Formal\ORM\{
     Specification\Entity,
     Specification\Child,
     Specification\Just,
+    Specification\Has,
 };
 use Innmind\Specification\{
     Specification,
@@ -108,6 +109,14 @@ final class Query
                         ],
                         $this->visit($specification->specification(), $specification->optional().'.'),
                     ],
+                ],
+            ];
+        }
+
+        if ($specification instanceof Has) {
+            return [
+                'exists' => [
+                    'field' => $specification->optional(),
                 ],
             ];
         }

--- a/src/Adapter/Filesystem/Fold.php
+++ b/src/Adapter/Filesystem/Fold.php
@@ -10,6 +10,7 @@ use Formal\ORM\{
     Specification\Entity as EntitySpecification,
     Specification\Child as ChildSpecification,
     Specification\Just as JustSpecification,
+    Specification\Has as HasSpecification,
 };
 use Innmind\Specification\{
     Specification,
@@ -99,6 +100,17 @@ final class Fold
                 ->flatMap(static fn($optional) => $optional->properties())
                 ->match(
                     static fn($properties) => $filter($properties),
+                    static fn() => false,
+                );
+        }
+
+        if ($specification instanceof HasSpecification) {
+            return static fn(Aggregate $aggregate) => $aggregate
+                ->optionals()
+                ->find(static fn($optional) => $optional->name() === $specification->optional())
+                ->flatMap(static fn($optional) => $optional->properties())
+                ->match(
+                    static fn() => true,
                     static fn() => false,
                 );
         }

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -12,6 +12,7 @@ use Formal\ORM\{
     Specification\Entity,
     Specification\Child,
     Specification\Just,
+    Specification\Has,
 };
 use Formal\AccessLayer\{
     Table,
@@ -367,6 +368,18 @@ final class MainTable
                     ->optional($specification->optional())
                     ->match(
                         static fn($optional) => $optional->where($specification->specification()),
+                        static fn() => throw new \LogicException("Unkown optional '{$specification->optional()}'"),
+                    ),
+            );
+        }
+
+        if ($specification instanceof Has) {
+            return SubQuery::of(
+                \sprintf('entity.%s', $this->definition->id()->property()),
+                $this
+                    ->optional($specification->optional())
+                    ->match(
+                        static fn($optional) => $optional->whereAny(),
                         static fn() => throw new \LogicException("Unkown optional '{$specification->optional()}'"),
                     ),
             );

--- a/src/Adapter/SQL/OptionalTable.php
+++ b/src/Adapter/SQL/OptionalTable.php
@@ -207,4 +207,9 @@ final class OptionalTable
             ->columns($this->id)
             ->where($specification);
     }
+
+    public function whereAny(): Query
+    {
+        return Select::from($this->name)->columns($this->id);
+    }
 }

--- a/src/Specification/Has.php
+++ b/src/Specification/Has.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Specification;
+
+use Innmind\Specification\{
+    Specification,
+    Composable,
+};
+
+/**
+ * @psalm-immutable
+ */
+final class Has implements Specification
+{
+    use Composable;
+
+    /** @var non-empty-string */
+    private string $optional;
+
+    /**
+     * @param non-empty-string $optional
+     */
+    private function __construct(string $optional)
+    {
+        $this->optional = $optional;
+    }
+
+    /**
+     * Use this specification to find an aggregate where the entity of the
+     * specified optional has a value. If no entity exists for the optional then
+     * the aggregate won't be matched.
+     *
+     * @psalm-pure
+     *
+     * @param non-empty-string $optional
+     */
+    public static function a(string $optional): self
+    {
+        return new self($optional);
+    }
+
+    /**
+     * Use this specification to find an aggregate where the entity of the
+     * specified optional has a value. If no entity exists for the optional then
+     * the aggregate won't be matched.
+     *
+     * @psalm-pure
+     *
+     * @param non-empty-string $optional
+     */
+    public static function an(string $optional): self
+    {
+        return new self($optional);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function optional(): string
+    {
+        return $this->optional;
+    }
+}

--- a/src/Specification/Normalize.php
+++ b/src/Specification/Normalize.php
@@ -151,6 +151,16 @@ final class Normalize
                 );
         }
 
+        if ($specification instanceof Has) {
+            return $this
+                ->optionals
+                ->get($specification->optional())
+                ->match(
+                    static fn() => $specification,
+                    static fn() => throw new \LogicException("Unknown optional '{$specification->optional()}'"),
+                );
+        }
+
         if ($specification instanceof Entity) {
             return $this
                 ->entities


### PR DESCRIPTION
## Request

It should be possible to match aggregates having an entity in an optional. 

The current `Just` specification require to use an arbitrary match on of the properties. Depending on the types used in may not always be possible. And it hides the true intention and may lead to implicit bugs.

## Solution

Add the `Has` specification to check if an optional has an entity. And this specification can be negated (as opposed to `Just`).