### PR TITLE
Allow to add if not exists statement to create table queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Formal\ORM\Adapter\SQL\ShowCreateTable::ifNotExists()`
+
 ## 3.3.0 - 2024-09-29
 
 ### Added

--- a/documentation/adapters/sql.md
+++ b/documentation/adapters/sql.md
@@ -110,6 +110,9 @@ CREATE TABLE  `user` (`id` varchar(36) NOT NULL  COMMENT 'UUID', `name` varchar(
 CREATE TABLE  `user_addresses` (`aggregateId` varchar(36) NOT NULL  COMMENT 'UUID', `street` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `zipCode` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `city` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE);
 ```
 
+??? tip
+    You can call `#!php $show->ifNotExists()(User::class)` to instead generate `CREATE TABLE IF NOT EXISTS` queries.
+
 Instead of printing the queries you can execute them directly like this:
 
 ```php title="show_create_tables.php" hl_lines="8 15-17 19"

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -54,6 +54,33 @@ return static function() {
                     SQL,
                 ])
                 ->same($queries);
+
+            $queries = $show->ifNotExists()(User::class)
+                ->map(static fn($query) => $query->sql(Driver::mysql))
+                ->toList();
+
+            $assert
+                ->expected([
+                    <<<SQL
+                    CREATE TABLE IF NOT EXISTS `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    SQL,
+                    <<<SQL
+                    CREATE TABLE IF NOT EXISTS `user_mainAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
+                    SQL,
+                    <<<SQL
+                    CREATE TABLE IF NOT EXISTS `user_billingAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_billingAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
+                    SQL,
+                    <<<SQL
+                    CREATE TABLE IF NOT EXISTS `user_sibling` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `id` char(36) NOT NULL  COMMENT 'UUID', CONSTRAINT `FK_user_sibling` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
+                    SQL,
+                    <<<SQL
+                    CREATE TABLE IF NOT EXISTS `user_addresses` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_addresses` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    SQL,
+                    <<<SQL
+                    CREATE TABLE IF NOT EXISTS `user_roles` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `name` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', CONSTRAINT `FK_user_roles` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE)
+                    SQL,
+                ])
+                ->same($queries);
         },
     )->tag(Storage::sql);
 


### PR DESCRIPTION
Allowing the `ShowCreateTable` class to generate `CREATE TABLE` queries suffixed with `IF NOT EXISTS` enables auto table creation for tools such as [`formal/migrations`](https://github.com/formal-php/migrations)