### PR TITLE
Reduce circular references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Use `static` closures as much as possible to reduce the probability of creating circular references by capturing `$this` as it can lead to memory root buffer exhaustion.
+
 ## 3.4.0 - 2024-10-02
 
 ### Added

--- a/src/Adapter/Elasticsearch/Decode.php
+++ b/src/Adapter/Elasticsearch/Decode.php
@@ -128,12 +128,17 @@ final class Decode
             default => Of::callable(static fn() => Validation::success($id)),
         };
 
-        return fn(mixed $content) => Maybe::all(
+        $properties = $this->properties;
+        $entities = $this->entities;
+        $optionals = $this->optionals;
+        $collections = $this->collections;
+
+        return static fn(mixed $content) => Maybe::all(
             Is::array()->and($id)($content)->maybe(),
-            ($this->properties)($content)->maybe(),
-            Is::array()->and($this->entities)($content)->maybe(),
-            Is::array()->and($this->optionals)($content)->maybe(),
-            Is::array()->and($this->collections)($content)->maybe(),
+            $properties($content)->maybe(),
+            Is::array()->and($entities)($content)->maybe(),
+            Is::array()->and($optionals)($content)->maybe(),
+            Is::array()->and($collections)($content)->maybe(),
         )->map(Aggregate::of(...));
     }
 

--- a/src/Adapter/Elasticsearch/Encode.php
+++ b/src/Adapter/Elasticsearch/Encode.php
@@ -26,8 +26,8 @@ final class Encode
         $entities = $data
             ->entities()
             ->exclude(static fn($entity) => $entity->properties()->empty())
-            ->map(fn($entity) => [
-                $entity->name() => $this->properties($entity->properties()),
+            ->map(static fn($entity) => [
+                $entity->name() => self::properties($entity->properties()),
             ])
             ->toList();
         $optionals = $data
@@ -36,20 +36,20 @@ final class Encode
                 static fn($properties) => $properties->empty(),
                 static fn() => false, // force setting the property to null below
             ))
-            ->map(fn($optional) => [
+            ->map(static fn($optional) => [
                 $optional->name() => $optional->properties()->match(
-                    $this->properties(...),
+                    self::properties(...),
                     static fn() => null,
                 ),
             ])
             ->toList();
         $collections = $data
             ->collections()
-            ->map(fn($collection) => [
+            ->map(static fn($collection) => [
                 $collection->name() => $collection
                     ->entities()
                     ->unsorted()
-                    ->map(fn($entity) => $this->properties($entity->properties()))
+                    ->map(static fn($entity) => self::properties($entity->properties()))
                     ->toList(),
             ])
             ->toList();
@@ -77,7 +77,7 @@ final class Encode
     /**
      * @param Sequence<Aggregate\Property> $properties
      */
-    private function properties(Sequence $properties): array
+    private static function properties(Sequence $properties): array
     {
         return \array_merge(
             ...$properties

--- a/src/Adapter/Filesystem/Decode.php
+++ b/src/Adapter/Filesystem/Decode.php
@@ -41,10 +41,11 @@ final class Decode
      */
     public function __invoke(Aggregate\Id $id = null): callable
     {
+        $property = $this->definition->id()->property();
         /** @psalm-suppress ArgumentTypeCoercion */
         $id = match ($id) {
-            null => fn(Directory $directory) => Aggregate\Id::of(
-                $this->definition->id()->property(),
+            null => static fn(Directory $directory) => Aggregate\Id::of(
+                $property,
                 $directory->name()->toString(),
             ),
             default => static fn(Directory $directory) => $id,
@@ -59,10 +60,12 @@ final class Decode
             $directory
                 ->get(Name::of('properties'))
                 ->keep(Instance::of(Directory::class))
+                ->memoize()
                 ->map(
                     static fn($properties) => $properties
                         ->all()
                         ->keep(Instance::of(File::class))
+                        ->memoize()
                         ->map(static fn($file) => Aggregate\Property::of(
                             $file->name()->toString(),
                             Json::decode($file->content()->toString()),
@@ -71,16 +74,19 @@ final class Decode
             $directory
                 ->get(Name::of('entities'))
                 ->keep(Instance::of(Directory::class))
+                ->memoize()
                 ->map(
                     static fn($entities) => $entities
                         ->all()
                         ->keep(Instance::of(Directory::class))
+                        ->memoize()
                         ->map(
                             static fn($entity) => Aggregate\Entity::of(
                                 $entity->name()->toString(),
                                 $entity
                                     ->all()
                                     ->keep(Instance::of(File::class))
+                                    ->memoize()
                                     ->map(static fn($property) => Aggregate\Property::of(
                                         $property->name()->toString(),
                                         Json::decode($property->content()->toString()),
@@ -91,20 +97,24 @@ final class Decode
             $directory
                 ->get(Name::of('optionals'))
                 ->keep(Instance::of(Directory::class))
+                ->memoize()
                 ->map(
                     static fn($optionals) => $optionals
                         ->all()
                         ->keep(Instance::of(Directory::class))
+                        ->memoize()
                         ->map(
                             static fn($optional) => Aggregate\Optional::of(
                                 $optional->name()->toString(),
                                 $optional
                                     ->get(Name::of('just'))
                                     ->keep(Instance::of(Directory::class))
+                                    ->memoize()
                                     ->map(
                                         static fn($just) => $just
                                             ->all()
                                             ->keep(Instance::of(File::class))
+                                            ->memoize()
                                             ->map(static fn($property) => Aggregate\Property::of(
                                                 $property->name()->toString(),
                                                 Json::decode($property->content()->toString()),
@@ -116,10 +126,12 @@ final class Decode
             $directory
                 ->get(Name::of('collections'))
                 ->keep(Instance::of(Directory::class))
+                ->memoize()
                 ->map(
                     static fn($collections) => $collections
                         ->all()
                         ->keep(Instance::of(File::class))
+                        ->memoize()
                         ->map(
                             static fn($collection) => Aggregate\Collection::of(
                                 $collection->name()->toString(),

--- a/src/Adapter/Filesystem/Repository.php
+++ b/src/Adapter/Filesystem/Repository.php
@@ -80,34 +80,34 @@ final class Repository implements RepositoryInterface
 
     public function add(Aggregate $data): void
     {
+        $encoded = Directory::named($this->definition->name())->add(
+            ($this->encode)($data),
+        );
+
         $this->transaction->mutate(
-            fn($adapter) => $adapter->add(
-                Directory::named($this->definition->name())->add(
-                    ($this->encode)($data),
-                ),
-            ),
+            static fn($adapter) => $adapter->add($encoded),
         );
     }
 
     public function update(Diff $data): void
     {
+        $encoded = Directory::named($this->definition->name())->add(
+            ($this->encode)($data),
+        );
+
         $this->transaction->mutate(
-            fn($adapter) => $adapter->add(
-                Directory::named($this->definition->name())->add(
-                    ($this->encode)($data),
-                ),
-            ),
+            static fn($adapter) => $adapter->add($encoded),
         );
     }
 
     public function remove(Aggregate\Id $id): void
     {
+        $mutated = Directory::named($this->definition->name())->remove(
+            Name::of($id->value()),
+        );
+
         $this->transaction->mutate(
-            fn($adapter) => $adapter->add(
-                Directory::named($this->definition->name())->remove(
-                    Name::of($id->value()),
-                ),
-            ),
+            static fn($adapter) => $adapter->add($mutated),
         );
     }
 

--- a/src/Adapter/SQL/Encode.php
+++ b/src/Adapter/SQL/Encode.php
@@ -60,11 +60,12 @@ final class Encode
      */
     private function entities(Aggregate $data): Sequence
     {
+        $mainTable = $this->mainTable;
+
         return $data
             ->entities()
             ->flatMap(
-                fn($entity) => $this
-                    ->mainTable
+                static fn($entity) => $mainTable
                     ->entity($entity->name())
                     ->map(
                         static fn($table) => $table->insert($data->id(), $entity->properties()),
@@ -78,11 +79,12 @@ final class Encode
      */
     private function optionals(Aggregate $data): Sequence
     {
+        $mainTable = $this->mainTable;
+
         return $data
             ->optionals()
             ->flatMap(
-                fn($optional) => $this
-                    ->mainTable
+                static fn($optional) => $mainTable
                     ->optional($optional->name())
                     ->flatMap(
                         static fn($table) => $optional->properties()->map(
@@ -106,11 +108,12 @@ final class Encode
      */
     private function collections(Aggregate $data): Sequence
     {
+        $mainTable = $this->mainTable;
+
         return $data
             ->collections()
             ->flatMap(
-                fn($collection) => $this
-                    ->mainTable
+                static fn($collection) => $mainTable
                     ->collection($collection->name())
                     ->toSequence()
                     ->flatMap(

--- a/src/Adapter/SQL/EntityTable.php
+++ b/src/Adapter/SQL/EntityTable.php
@@ -136,11 +136,13 @@ final class EntityTable
      */
     public function update(Id $id, Sequence $properties): Maybe
     {
+        $name = $this->name;
+
         return Maybe::just($properties)
             ->filter(static fn($properties) => !$properties->empty())
             ->map(
-                fn($properties) => Update::set(
-                    $this->name,
+                static fn($properties) => Update::set(
+                    $name,
                     Row::new(
                         ...$properties
                             ->map(static fn($property) => Row\Value::of(

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -260,11 +260,12 @@ final class MainTable
     public function update(Diff $data): Maybe
     {
         $table = $this->name->name();
+        $id = $this->definition->id()->property();
 
         return Maybe::just($data->properties())
             ->filter(static fn($properties) => !$properties->empty())
             ->map(
-                fn($properties) => Update::set(
+                static fn($properties) => Update::set(
                     $table,
                     Row::new(
                         ...$properties
@@ -275,7 +276,7 @@ final class MainTable
                             ->toList(),
                     ),
                 )->where(Property::of(
-                    $this->definition->id()->property(),
+                    $id,
                     Sign::equality,
                     $data->id()->value(),
                 )),

--- a/src/Adapter/SQL/Transaction.php
+++ b/src/Adapter/SQL/Transaction.php
@@ -44,9 +44,11 @@ final class Transaction implements TransactionInterface
      */
     public function commit(): callable
     {
-        return function(mixed $value) {
+        $connection = $this->connection;
+
+        return static function(mixed $value) use ($connection) {
             // memoize to force unwrap the monad
-            $_ = ($this->connection)(new Commit)->memoize();
+            $_ = $connection(new Commit)->memoize();
 
             return $value;
         };
@@ -59,9 +61,11 @@ final class Transaction implements TransactionInterface
      */
     public function rollback(): callable
     {
-        return function(mixed $value) {
+        $connection = $this->connection;
+
+        return static function(mixed $value) use ($connection) {
             // memoize to force unwrap the monad
-            $_ = ($this->connection)(new Rollback)->memoize();
+            $_ = $connection(new Rollback)->memoize();
 
             return $value;
         };

--- a/src/Adapter/SQL/Update.php
+++ b/src/Adapter/SQL/Update.php
@@ -30,12 +30,12 @@ final class Update
      */
     public function __invoke(Diff $data): Sequence
     {
+        $mainTable = $this->mainTable;
         $main = $this->mainTable->update($data)->toSequence();
         $entities = $data
             ->entities()
             ->flatMap(
-                fn($entity) => $this
-                    ->mainTable
+                static fn($entity) => $mainTable
                     ->entity($entity->name())
                     ->flatMap(
                         static fn($table) => $table->update(
@@ -48,8 +48,7 @@ final class Update
         $optionals = $data
             ->optionals()
             ->flatMap(
-                fn($optional) => $this
-                    ->mainTable
+                static fn($optional) => $mainTable
                     ->optional($optional->name())
                     ->toSequence()
                     ->flatMap(static fn($table) => $table->update(
@@ -60,8 +59,7 @@ final class Update
         $collections = $data
             ->collections()
             ->flatMap(
-                fn($collection) => $this
-                    ->mainTable
+                static fn($collection) => $mainTable
                     ->collection($collection->name())
                     ->toSequence()
                     ->flatMap(static fn($table) => $table->update(

--- a/src/Matching.php
+++ b/src/Matching.php
@@ -306,6 +306,9 @@ final class Matching
             $specification = ($this->normalizeSpecification)($this->specification);
         }
 
+        $loaded = $this->loaded;
+        $repository = $this->repository;
+
         return $this
             ->adapter
             ->fetch(
@@ -315,8 +318,8 @@ final class Matching
                 $this->take,
             )
             ->map($denormalize)
-            ->map(fn($denormalized) => $this->loaded->add(
-                $this->repository,
+            ->map(static fn($denormalized) => $loaded->add(
+                $repository,
                 $denormalized,
             ))
             ->map($this->instanciate);

--- a/src/Repository/Denormalize/Collection.php
+++ b/src/Repository/Denormalize/Collection.php
@@ -74,16 +74,17 @@ final class Collection
         }
 
         $class = $this->definition->class();
+        $properties = $this->properties;
+        $instanciate = $this->instanciate;
 
         return $collection
             ->entities()
-            ->map(function($entity) use ($class) {
+            ->map(static function($entity) use ($class, $properties, $instanciate) {
                 $entity = Map::of(
                     ...$entity
                         ->properties()
                         ->flatMap(
-                            fn($property) => $this
-                                ->properties
+                            static fn($property) => $properties
                                 ->get($property->name())
                                 ->map(static fn($definition): mixed => $definition->type()->denormalize($property->value()))
                                 ->map(static fn($value) => [$property->name(), $value])
@@ -93,7 +94,7 @@ final class Collection
                 );
 
                 /** @var T */
-                return ($this->instanciate)($class, $entity)->match(
+                return $instanciate($class, $entity)->match(
                     static fn($object) => $object,
                     static fn() => throw new \RuntimeException("Unable to denormalize collection of type '$class'"),
                 );

--- a/src/Repository/Denormalize/Optional.php
+++ b/src/Repository/Denormalize/Optional.php
@@ -47,15 +47,16 @@ final class Optional
     public function __invoke(Raw $optional): Maybe
     {
         $class = $this->definition->class();
+        $props = $this->properties;
+        $instanciate = $this->instanciate;
 
         return $optional
             ->properties()
-            ->map(function($properties) use ($class) {
+            ->map(static function($properties) use ($class, $props, $instanciate) {
                 $properties = Map::of(
                     ...$properties
                         ->flatMap(
-                            fn($property) => $this
-                                ->properties
+                            static fn($property) => $props
                                 ->get($property->name())
                                 ->map(static fn($definition): mixed => $definition->type()->denormalize($property->value()))
                                 ->map(static fn($value) => [$property->name(), $value])
@@ -65,7 +66,7 @@ final class Optional
                 );
 
                 /** @var T */
-                return ($this->instanciate)($class, $properties)->match(
+                return $instanciate($class, $properties)->match(
                     static fn($optional) => $optional,
                     static fn() => throw new \RuntimeException("Unable to denormalize optional of type '$class'"),
                 );

--- a/src/Repository/Diff.php
+++ b/src/Repository/Diff.php
@@ -81,6 +81,11 @@ final class Diff
         $then = $then->properties();
         $now = $now->properties();
 
+        $definition = $this->definition;
+        $normalizeEntity = $this->normalizeEntity;
+        $normalizeOptional = $this->normalizeOptional;
+        $normalizeCollection = $this->normalizeCollection;
+
         // Diffing on denormalized values that has to be immutable we allow to
         // not unwrap monads (such as Maybe for optionals) unless necessary,
         // thus avoiding possible roundtrips to the storage adapter
@@ -102,8 +107,7 @@ final class Diff
             ->values();
 
         $properties = $diff->flatMap(
-            fn($value) => $this
-                ->definition
+            static fn($value) => $definition
                 ->properties()
                 ->find(static fn($property) => $property->name() === $value->name())
                 ->map(static fn($property) => Raw\Aggregate\Property::of(
@@ -114,8 +118,7 @@ final class Diff
         );
         /** @psalm-suppress MixedArgument */
         $entities = $diff->flatMap(
-            fn($value) => $this
-                ->normalizeEntity
+            static fn($value) => $normalizeEntity
                 ->get($value->name())
                 ->map(static fn($normalize) => self::diffEntities(
                     $normalize($value->then()),
@@ -125,8 +128,7 @@ final class Diff
         );
         /** @psalm-suppress MixedArgument */
         $optionals = $diff->flatMap(
-            fn($value) => $this
-                ->normalizeOptional
+            static fn($value) => $normalizeOptional
                 ->get($value->name())
                 ->map(static fn($normalize) => self::diffOptionals(
                     $normalize($value->then()),
@@ -144,8 +146,7 @@ final class Diff
          * @psalm-suppress MixedReturnStatement
          */
         $collections = $diff->flatMap(
-            fn($value) => $this
-                ->normalizeCollection
+            static fn($value) => $normalizeCollection
                 ->get($value->name())
                 ->exclude(static fn(): bool => $value->now()->equals($value->then()))
                 ->map(static fn($normalize) => $normalize($value->now()))

--- a/src/Repository/Normalize.php
+++ b/src/Repository/Normalize.php
@@ -68,6 +68,9 @@ final class Normalize
     public function __invoke(Denormalized $denormalized): Aggregate
     {
         $properties = $denormalized->properties();
+        $normalizeEntity = $this->normalizeEntity;
+        $normalizeOptional = $this->normalizeOptional;
+        $normalizeCollection = $this->normalizeCollection;
 
         /** @psalm-suppress MixedArgument Due to the collection normalization */
         return Aggregate::of(
@@ -88,8 +91,7 @@ final class Normalize
                 ->definition
                 ->entities()
                 ->flatMap(
-                    fn($entity) => $this
-                        ->normalizeEntity
+                    static fn($entity) => $normalizeEntity
                         ->get($entity)
                         ->flatMap(
                             static fn($normalize) => $properties
@@ -102,8 +104,7 @@ final class Normalize
                 ->definition
                 ->optionals()
                 ->flatMap(
-                    fn($optional) => $this
-                        ->normalizeOptional
+                    static fn($optional) => $normalizeOptional
                         ->get($optional)
                         ->flatMap(
                             static fn($normalize) => $properties
@@ -116,8 +117,7 @@ final class Normalize
                 ->definition
                 ->collections()
                 ->flatMap(
-                    fn($collection) => $this
-                        ->normalizeCollection
+                    static fn($collection) => $normalizeCollection
                         ->get($collection)
                         ->flatMap(
                             static fn($normalize) => $properties

--- a/src/Repository/Normalize/Collection.php
+++ b/src/Repository/Normalize/Collection.php
@@ -43,9 +43,12 @@ final class Collection
      */
     public function __invoke(Set $collection): Raw
     {
+        $definition = $this->definition;
         $class = $this->definition->class();
+        $properties = $this->properties;
+        $extract = $this->extract;
         $entities = $collection->map(
-            fn($object) => ($this->extract)($object, $this->properties)->match(
+            static fn($object) => $extract($object, $properties)->match(
                 static fn($entity) => $entity,
                 static fn() => throw new \LogicException("Failed to extract properties from '$class'"),
             ),
@@ -55,8 +58,7 @@ final class Collection
             $this->definition->name(),
             $entities
                 ->map(
-                    fn($entity) => $this
-                        ->definition
+                    static fn($entity) => $definition
                         ->properties()
                         ->flatMap(
                             static fn($property) => $entity

--- a/src/Repository/Normalize/Optional.php
+++ b/src/Repository/Normalize/Optional.php
@@ -44,9 +44,12 @@ final class Optional
      */
     public function __invoke(Maybe $optional): Raw
     {
+        $definition = $this->definition;
         $class = $this->definition->class();
+        $properties = $this->properties;
+        $extract = $this->extract;
         $properties = $optional->map(
-            fn($object) => ($this->extract)($object, $this->properties)->match(
+            static fn($object) => $extract($object, $properties)->match(
                 static fn($properties) => $properties,
                 static fn() => throw new \LogicException("Failed to extract properties from '$class'"),
             ),
@@ -55,8 +58,7 @@ final class Optional
         return Raw::of(
             $this->definition->name(),
             $properties->map(
-                fn($properties) => $this
-                    ->definition
+                static fn($properties) => $definition
                     ->properties()
                     ->flatMap(
                         static fn($property) => $properties


### PR DESCRIPTION
## Problem

Same as https://github.com/Innmind/framework/pull/3

## Solution

Same as https://github.com/Innmind/framework/pull/3

## Note

There are remaining closures that still capture `$this` but they should be directly evaluated, meaning the reference is short lived. This should not cause any problem.