### PR TITLE
Fix cross matching on an aggregate or entity property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Cross matching on an aggregate or entity property.
+
 ## 3.4.1 - 2024-10-26
 
 ### Changed

--- a/properties/CrossAggregateMatching.php
+++ b/properties/CrossAggregateMatching.php
@@ -126,6 +126,35 @@ final class CrossAggregateMatching implements Property
 
         $assert->count(0, $found);
 
+        // this allows to check the cross match on aggregate properties
+        $found = $repository
+            ->matching(Comparator\Property::of(
+                'id',
+                Sign::in,
+                $repository->matching(
+                    Comparator\Property::of('id', Sign::equality, $child1->id())->or(
+                        Comparator\Property::of('id', Sign::equality, $parent2->id()),
+                    ),
+                ),
+            ))
+            ->map(static fn($user) => $user->id()->toString())
+            ->toList();
+
+        $assert
+            ->expected($child1->id()->toString())
+            ->in($found);
+        $assert
+            ->expected($parent2->id()->toString())
+            ->in($found);
+        $assert
+            ->expected($child2->id()->toString())
+            ->not()
+            ->in($found);
+        $assert
+            ->expected($parent1->id()->toString())
+            ->not()
+            ->in($found);
+
         return $manager;
     }
 }

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -13,6 +13,7 @@ use Formal\ORM\{
     Specification\Child,
     Specification\Just,
     Specification\Has,
+    Specification\CrossMatch,
 };
 use Formal\AccessLayer\{
     Table,
@@ -27,6 +28,7 @@ use Formal\AccessLayer\{
 use Innmind\Specification\{
     Specification,
     Not,
+    Comparator,
     Composite,
     Operator,
     Sign,
@@ -404,6 +406,14 @@ final class MainTable
             );
         }
 
+        if ($specification instanceof CrossMatch) {
+            return Comparator\Property::of(
+                'entity.'.$specification->property(),
+                $specification->sign(),
+                $specification->value(),
+            );
+        }
+
         if (!($specification instanceof Property)) {
             $class = $specification::class;
 
@@ -444,6 +454,18 @@ final class MainTable
                 Operator::and => $left->and($right),
                 Operator::or => $left->or($right),
             };
+        }
+
+        if ($underlying instanceof CrossMatch) {
+            return Comparator\Property::of(
+                \sprintf(
+                    '%s.%s',
+                    $specification->entity(),
+                    $underlying->property(),
+                ),
+                $underlying->sign(),
+                $underlying->value(),
+            );
         }
 
         if (!($underlying instanceof Property)) {


### PR DESCRIPTION
## Problem

#37 introduced cross aggregate matching. However the PR only tested against an optional entity.

When applying this feature on an aggregate or entity property then it throws a `LogicException` with the SQL adapter saying the specification `CrossMatch` is not supported.

## Solution

Add missing specification translations in the SQL adapter to allow to apply it in these cases.