### PR TITLE
Allow to convert a type to a floating point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow to convert types to floating points.
+
 ### Fixed
 
 - Cross matching on an aggregate or entity property.

--- a/documentation/blog/posts/float-support.md
+++ b/documentation/blog/posts/float-support.md
@@ -1,0 +1,93 @@
+---
+authors: [baptouuuu]
+date: 2024-10-31
+---
+
+# Adding `float` support (kinda...)
+
+In the latest release Formal now allows to store `float`s in any storage.
+
+<!-- more -->
+
+So far Formal didn't allow to use `float`s at the storage level on purpose. Handling this type is [tricky](../../issues.md#floating-points) due to the precision to use, rounding errors and implicit convertions.
+
+By avoiding to support it, it also avoided to bring associated bugs.
+
+However in certain cases we _do_ need to store values as `float`s.
+
+In order to reconcile this need with the intention to not bring the associated bugs, Formal brings a partial support. It now allows to normalize a type to a `float` **but** it doesn't support `float` as a property type.
+
+This means that if you want to represent a tax for example you can't type your aggregate like this:
+
+```php hl_lines="4"
+final readonly class SomeAggregate
+{
+    private Id $id;
+    private float $tax;
+}
+```
+
+By default Formal will ignore this property and won't store it. Instead you need to [write a custom type](../../mapping/type.md):
+
+=== "`Tax`"
+    ```php
+    final readonly class Tax
+    {
+        public function __construct(
+            private float $value,
+        ) {}
+
+        public function toFloat(): float
+        {
+            return $this->value;
+        }
+    }
+    ```
+
+=== "`SomeAggregate`"
+    ```php hl_lines="4"
+    final readonly class SomeAggregate
+    {
+        private Id $id;
+        private Tax $tax;
+    }
+    ```
+
+=== "`TaxType`"
+    ```php
+    use Formal\ORM\Definition\Type;
+
+    /**
+     * @psalm-immutable
+     * @implements Type<Tax>
+     */
+    final class TaxType implements Type
+    {
+        public function normalize(mixed $value): null|string|int|float|bool
+        {
+            return $value->toFloat();
+        }
+
+        public function denormalize(null|string|int|float|bool $value): mixed
+        {
+            if (!\is_numeric($value)) { #(1)
+                throw new \LogicException("'$value' is not a string");
+            }
+
+            return new Tax($value + 0); #(2)
+        }
+    }
+    ```
+
+    1. In SQL the value will be read as a `string`.
+    2. The `+ 0` allows to convert the `string` (when read from SQL) to either an `int` or `float` without changing the value.
+
+You can then implement [`SQLType`](../../adapters/sql.md#mapping) or [`ElasticsearchType`](../../adapters/elasticsearch.md#mapping) on `TaxType` to choose the precision to use at the storage level.
+
+??? note
+    You can't choose the precision for the [Filesystem adapter](../../adapters/filesystem.md) as the value is stored as a JSON string.
+
+!!! success ""
+    With this approach Formal let you use `float`s if you need to and at the same time forces you to think about the precision you want/need.
+
+    _You_ control what's happening, no implicits.

--- a/documentation/issues.md
+++ b/documentation/issues.md
@@ -42,6 +42,21 @@ $orm = Manager::of(
 
     This behaviour won't be change for the time being to not break existing projects. But you can gradually fix this via the `mapName` method.
 
+### Floating points
+
+By default Formal doesn't support `float` as a property type _but_ it allows you to use it if you need to.
+
+Storing `float`s is a tricky business because of the decimal part precision. Not every system will represent the same value the same way and you may end up with implicit convertions. Meaning you may not retrieve the exact value you put in.
+
+Formal tries to be as explicit as it can be. Supporting by default a type with implicit behaviours is a sure way to bugs.
+
+That being said you can still create a [custom type](mapping/type.md) and normalize that type to a `float` at the storage level. This way you have to determine how to represent the value in your storage and can control the precision.
+
+??? info
+    If you're not familiar with the `float` problems, you can read this, rather long, [article from Oracle](https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html) on how floating points are represented by a system and errors associated.
+
+    You can also watch this [talk](https://www.youtube.com/watch?v=0iEKP4tsWe0) (in french).
+
 ## Elasticsearch
 
 ### Searching with `endsWith`

--- a/documentation/mapping/index.md
+++ b/documentation/mapping/index.md
@@ -14,7 +14,7 @@ Using primitive types is fine when you prototype the design of your aggregates. 
 
 1. It also has the benefit to immensely simplify refactoring your code.
 
-Types is essential in the Formal design. You'll learn in the next chapter how to support your custom types.
+Types are essential in the Formal design. You'll learn in the next chapter how to support your custom types.
 
 By default Formal also supports:
 

--- a/documentation/mapping/type.md
+++ b/documentation/mapping/type.md
@@ -69,12 +69,12 @@ use Formal\ORM\Definition\Type;
  */
 final class NameType implements Type
 {
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value->toString();
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         if (!\is_string($value)) {
             throw new \LogicException("'$value' is not a string");

--- a/fixtures/CreatedAt.php
+++ b/fixtures/CreatedAt.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types = 1);
+
+namespace Fixtures\Formal\ORM;
+
+/**
+ * @psalm-immutable
+ */
+final class CreatedAt
+{
+    private float $value;
+
+    public function __construct(float $value)
+    {
+        $this->value = $value;
+    }
+
+    public function toFloat(): float
+    {
+        return $this->value;
+    }
+}

--- a/fixtures/CreatedAtType.php
+++ b/fixtures/CreatedAtType.php
@@ -56,10 +56,13 @@ final class CreatedAtType implements Type, SQLType, ElasticsearchType
 
     public function denormalize(null|string|int|float|bool $value): mixed
     {
-        if (!\is_float($value) && !\is_int($value)) {
+        if (!\is_numeric($value)) {
             throw new \LogicException("'$value' is not a float");
         }
 
-        return new CreatedAt($value);
+        // With SQL the value is read from the database as a string. Adding 0
+        // allows to convert the string to the correct type (int or float)
+        // without modifying its value.
+        return new CreatedAt($value + 0);
     }
 }

--- a/fixtures/CreatedAtType.php
+++ b/fixtures/CreatedAtType.php
@@ -56,7 +56,7 @@ final class CreatedAtType implements Type, SQLType, ElasticsearchType
 
     public function denormalize(null|string|int|float|bool $value): mixed
     {
-        if (!\is_float($value)) {
+        if (!\is_float($value) && !\is_int($value)) {
             throw new \LogicException("'$value' is not a float");
         }
 

--- a/fixtures/CreatedAtType.php
+++ b/fixtures/CreatedAtType.php
@@ -3,12 +3,14 @@ declare(strict_types = 1);
 
 namespace Fixtures\Formal\ORM;
 
-use Fixtures\Formal\ORM\Sortable;
+use Fixtures\Formal\ORM\CreatedAt;
 use Formal\ORM\Adapter\Elasticsearch\ElasticsearchType;
+use Formal\ORM\Adapter\SQL\SQLType;
 use Formal\ORM\Definition\{
     Type,
     Types,
 };
+use Formal\AccessLayer\Table\Column\Type as Definition;
 use Innmind\Type\{
     Type as Concrete,
     ClassName,
@@ -17,9 +19,9 @@ use Innmind\Immutable\Maybe;
 
 /**
  * @psalm-immutable
- * @implements Type<Sortable>
+ * @implements Type<CreatedAt>
  */
-final class SortableType implements Type, ElasticsearchType
+final class CreatedAtType implements Type, SQLType, ElasticsearchType
 {
     private function __construct()
     {
@@ -33,26 +35,31 @@ final class SortableType implements Type, ElasticsearchType
     public static function of(Types $types, Concrete $type): Maybe
     {
         return Maybe::just($type)
-            ->filter(static fn($type) => $type->accepts(ClassName::of(Sortable::class)))
+            ->filter(static fn($type) => $type->accepts(ClassName::of(CreatedAt::class)))
             ->map(static fn() => new self);
     }
 
     public function elasticsearchType(): array
     {
-        return ['type' => 'keyword'];
+        return ['type' => 'double'];
+    }
+
+    public function sqlType(): Definition
+    {
+        return Definition::decimal(65, 2);
     }
 
     public function normalize(mixed $value): null|string|int|float|bool
     {
-        return $value->toString();
+        return $value->toFloat();
     }
 
     public function denormalize(null|string|int|float|bool $value): mixed
     {
-        if (!\is_string($value)) {
-            throw new \LogicException("'$value' is not a string");
+        if (!\is_float($value)) {
+            throw new \LogicException("'$value' is not a float");
         }
 
-        return new Sortable($value);
+        return new CreatedAt($value);
     }
 }

--- a/fixtures/User.php
+++ b/fixtures/User.php
@@ -19,6 +19,9 @@ final class User
     /** @var Id<self> */
     private Id $id;
     private PointInTime $createdAt;
+    // To show by default floats are not supported on purpose
+    private float $createdAtFloat;
+    private CreatedAt $wrappedCreatedAt;
     private ?string $name;
     /** @var Maybe<Str> */
     #[Contains(Str::class)]
@@ -66,6 +69,12 @@ final class User
     ) {
         $this->id = $id;
         $this->createdAt = $createdAt;
+        $this->createdAtFloat = (float) \sprintf(
+            '%s.%s',
+            $createdAt->second()->toInt(),
+            $createdAt->millisecond()->toInt(),
+        );
+        $this->wrappedCreatedAt = new CreatedAt($this->createdAtFloat);
         $this->name = $name;
         $this->nameStr = Maybe::of($name)->map(Str::of(...));
         $this->sortableName = Sortable::of($name);

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -12,7 +12,10 @@ use Innmind\TimeContinuum\{
     Earth\Clock,
     PointInTime,
 };
-use Fixtures\Formal\ORM\User;
+use Fixtures\Formal\ORM\{
+    User,
+    CreatedAtType,
+};
 
 return static function() {
     yield test(
@@ -23,6 +26,7 @@ return static function() {
                     PointInTime::class,
                     Type\PointInTimeType::new(new Clock),
                 ),
+                CreatedAtType::of(...),
             ));
 
             $mapping = Mapping::new()($aggregates->get(User::class));
@@ -35,6 +39,9 @@ return static function() {
                         ],
                         'createdAt' => [
                             'type' => 'text',
+                        ],
+                        'wrappedCreatedAt' => [
+                            'type' => 'double',
                         ],
                         'name' => [
                             'type' => 'text',

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -13,7 +13,10 @@ use Innmind\TimeContinuum\{
     Earth\Clock,
     PointInTime,
 };
-use Fixtures\Formal\ORM\User;
+use Fixtures\Formal\ORM\{
+    User,
+    CreatedAtType,
+};
 
 return static function() {
     yield test(
@@ -25,6 +28,7 @@ return static function() {
                         PointInTime::class,
                         Type\PointInTimeType::new(new Clock),
                     ),
+                    CreatedAtType::of(...),
                 )),
             );
 
@@ -35,7 +39,7 @@ return static function() {
             $assert
                 ->expected([
                     <<<SQL
-                    CREATE TABLE  `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE  `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
                     CREATE TABLE  `user_mainAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
@@ -62,7 +66,7 @@ return static function() {
             $assert
                 ->expected([
                     <<<SQL
-                    CREATE TABLE IF NOT EXISTS `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE IF NOT EXISTS `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
                     CREATE TABLE IF NOT EXISTS `user_mainAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
@@ -93,6 +97,7 @@ return static function() {
                         PointInTime::class,
                         Type\PointInTimeType::new(new Clock),
                     ),
+                    CreatedAtType::of(...),
                 ))->mapName(static fn($string) => match ($string) {
                     User::class => 'some_user',
                 }),
@@ -108,7 +113,7 @@ return static function() {
             $assert
                 ->expected(
                     <<<SQL
-                    CREATE TABLE  `some_user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE  `some_user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                 )
                 ->in($queries);

--- a/proofs/manager.php
+++ b/proofs/manager.php
@@ -88,7 +88,7 @@ return static function() {
             Aggregates::of(Types::of(
                 Type\PointInTimeType::of(new Clock),
                 SortableType::of(...),
-                CreateAtType::of(...),
+                CreatedAtType::of(...),
             )),
         )),
     )->tag(Storage::filesystem);
@@ -104,7 +104,7 @@ return static function() {
                         Type\PointInTimeType::new(new Clock),
                     ),
                     SortableType::of(...),
-                    CreateAtType::of(...),
+                    CreatedAtType::of(...),
                 )),
             )),
         )
@@ -119,7 +119,7 @@ return static function() {
             Type\PointInTimeType::new($os->clock()),
         ),
         SortableType::of(...),
-        CreateAtType::of(...),
+        CreatedAtType::of(...),
     ));
 
     $sql = static function(Url $dsn, string $driver) use ($os, $aggregates) {

--- a/proofs/manager.php
+++ b/proofs/manager.php
@@ -15,6 +15,7 @@ use Fixtures\Formal\ORM\{
     User,
     Random,
     SortableType,
+    CreatedAtType,
 };
 use Properties\Formal\ORM\{
     Properties,
@@ -87,6 +88,7 @@ return static function() {
             Aggregates::of(Types::of(
                 Type\PointInTimeType::of(new Clock),
                 SortableType::of(...),
+                CreateAtType::of(...),
             )),
         )),
     )->tag(Storage::filesystem);
@@ -102,6 +104,7 @@ return static function() {
                         Type\PointInTimeType::new(new Clock),
                     ),
                     SortableType::of(...),
+                    CreateAtType::of(...),
                 )),
             )),
         )
@@ -116,6 +119,7 @@ return static function() {
             Type\PointInTimeType::new($os->clock()),
         ),
         SortableType::of(...),
+        CreateAtType::of(...),
     ));
 
     $sql = static function(Url $dsn, string $driver) use ($os, $aggregates) {

--- a/src/Adapter/Filesystem/Fold.php
+++ b/src/Adapter/Filesystem/Fold.php
@@ -151,19 +151,19 @@ final class Fold
     }
 
     /**
-     * @return callable(null|string|int|bool): bool
+     * @return callable(null|string|int|float|bool): bool
      */
     private function filter(Comparator $specification): callable
     {
         /** @psalm-suppress MixedArgument */
         return match ($specification->sign()) {
-            Sign::equality => static fn(null|string|int|bool $value): bool => $value === $specification->value(),
-            Sign::lessThan => static fn(null|string|int|bool $value): bool => $value < $specification->value(),
-            Sign::moreThan => static fn(null|string|int|bool $value): bool => $value > $specification->value(),
-            Sign::startsWith => static fn(null|string|int|bool $value): bool => \is_string($value) && \str_starts_with($value, $specification->value()),
-            Sign::endsWith => static fn(null|string|int|bool $value): bool => \is_string($value) && \str_ends_with($value, $specification->value()),
-            Sign::contains => static fn(null|string|int|bool $value): bool => \is_string($value) && \str_contains($value, $specification->value()),
-            Sign::in => static fn(null|string|int|bool $value): bool => \in_array($value, $specification->value(), true),
+            Sign::equality => static fn(null|string|int|float|bool $value): bool => $value === $specification->value(),
+            Sign::lessThan => static fn(null|string|int|float|bool $value): bool => $value < $specification->value(),
+            Sign::moreThan => static fn(null|string|int|float|bool $value): bool => $value > $specification->value(),
+            Sign::startsWith => static fn(null|string|int|float|bool $value): bool => \is_string($value) && \str_starts_with($value, $specification->value()),
+            Sign::endsWith => static fn(null|string|int|float|bool $value): bool => \is_string($value) && \str_ends_with($value, $specification->value()),
+            Sign::contains => static fn(null|string|int|float|bool $value): bool => \is_string($value) && \str_contains($value, $specification->value()),
+            Sign::in => static fn(null|string|int|float|bool $value): bool => \in_array($value, $specification->value(), true),
         };
     }
 

--- a/src/Adapter/Filesystem/Repository.php
+++ b/src/Adapter/Filesystem/Repository.php
@@ -140,8 +140,8 @@ final class Repository implements RepositoryInterface
 
         if ($sort) {
             $compare = match ($sort->direction()) {
-                Sort::asc => static fn(null|string|int|bool $a, null|string|int|bool $b) => $a <=> $b,
-                Sort::desc => static fn(null|string|int|bool $a, null|string|int|bool $b) => $b <=> $a,
+                Sort::asc => static fn(null|string|int|float|bool $a, null|string|int|float|bool $b) => $a <=> $b,
+                Sort::desc => static fn(null|string|int|float|bool $a, null|string|int|float|bool $b) => $b <=> $a,
             };
             $pluck = match (true) {
                 $sort instanceof Sort\Property => static fn(Aggregate $x): mixed => $x

--- a/src/Definition/Type.php
+++ b/src/Definition/Type.php
@@ -12,10 +12,10 @@ interface Type
     /**
      * @param D $value
      */
-    public function normalize(mixed $value): null|string|int|bool;
+    public function normalize(mixed $value): null|string|int|float|bool;
 
     /**
      * @return D
      */
-    public function denormalize(null|string|int|bool $value): mixed;
+    public function denormalize(null|string|int|float|bool $value): mixed;
 }

--- a/src/Definition/Type/BoolType.php
+++ b/src/Definition/Type/BoolType.php
@@ -35,12 +35,12 @@ final class BoolType implements Type
             ->map(static fn() => new self);
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value;
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         return match ($value) {
             0 => false,

--- a/src/Definition/Type/EnumType.php
+++ b/src/Definition/Type/EnumType.php
@@ -51,12 +51,12 @@ final class EnumType implements Type
             ->map(static fn($type) => new self($type->toString()));
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value->name;
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         foreach ($this->class::cases() as $case) {
             if ($case->name === $value) {

--- a/src/Definition/Type/IdType.php
+++ b/src/Definition/Type/IdType.php
@@ -36,12 +36,12 @@ final class IdType implements Type
             ->map(static fn() => new self);
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value->toString();
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         if (!\is_string($value)) {
             throw new \LogicException("'$value' is not a string");

--- a/src/Definition/Type/IntType.php
+++ b/src/Definition/Type/IntType.php
@@ -35,12 +35,12 @@ final class IntType implements Type
             ->map(static fn() => new self);
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value;
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         if (!\is_int($value)) {
             throw new \LogicException("'$value' is not an integer");

--- a/src/Definition/Type/MaybeType.php
+++ b/src/Definition/Type/MaybeType.php
@@ -54,7 +54,7 @@ final class MaybeType implements Type
         return $this->inner;
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value->match(
             $this->inner->normalize(...),
@@ -62,7 +62,7 @@ final class MaybeType implements Type
         );
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         return Maybe::of($value)->map($this->inner->denormalize(...));
     }

--- a/src/Definition/Type/NullableType.php
+++ b/src/Definition/Type/NullableType.php
@@ -55,7 +55,7 @@ final class NullableType implements Type
         return $this->inner;
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         if (\is_null($value)) {
             return null;
@@ -64,7 +64,7 @@ final class NullableType implements Type
         return $this->inner->normalize($value);
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         if (\is_null($value)) {
             return null;

--- a/src/Definition/Type/PointInTimeType.php
+++ b/src/Definition/Type/PointInTimeType.php
@@ -55,12 +55,12 @@ final class PointInTimeType implements Type
             ->map(static fn() => new self($clock, new Format));
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value->format($this->format);
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         if (!\is_string($value)) {
             throw new \LogicException("'$value' is not a string");

--- a/src/Definition/Type/StrType.php
+++ b/src/Definition/Type/StrType.php
@@ -24,12 +24,12 @@ final class StrType implements Type
         return new self;
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value->toString();
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         if (!\is_string($value)) {
             throw new \LogicException("'$value' is not a string");

--- a/src/Definition/Type/StringType.php
+++ b/src/Definition/Type/StringType.php
@@ -43,12 +43,12 @@ final class StringType implements Type
             ->map(static fn() => new self);
     }
 
-    public function normalize(mixed $value): null|string|int|bool
+    public function normalize(mixed $value): null|string|int|float|bool
     {
         return $value;
     }
 
-    public function denormalize(null|string|int|bool $value): mixed
+    public function denormalize(null|string|int|float|bool $value): mixed
     {
         if (!\is_string($value)) {
             throw new \LogicException("'$value' is not a string");

--- a/src/Raw/Aggregate/Property.php
+++ b/src/Raw/Aggregate/Property.php
@@ -10,12 +10,12 @@ final class Property
 {
     /** @var non-empty-string */
     private string $name;
-    private null|string|int|bool $value;
+    private null|string|int|float|bool $value;
 
     /**
      * @param non-empty-string $name
      */
-    private function __construct(string $name, null|string|int|bool $value)
+    private function __construct(string $name, null|string|int|float|bool $value)
     {
         $this->name = $name;
         $this->value = $value;
@@ -26,7 +26,7 @@ final class Property
      *
      * @param non-empty-string $name
      */
-    public static function of(string $name, null|string|int|bool $value): self
+    public static function of(string $name, null|string|int|float|bool $value): self
     {
         return new self($name, $value);
     }
@@ -39,7 +39,7 @@ final class Property
         return $this->name;
     }
 
-    public function value(): null|string|int|bool
+    public function value(): null|string|int|float|bool
     {
         return $this->value;
     }

--- a/src/Specification/Normalize.php
+++ b/src/Specification/Normalize.php
@@ -253,13 +253,13 @@ final class Normalize
      * @param Map<non-empty-string, Aggregate\Property> $properties
      * @param non-empty-string $property
      *
-     * @return null|string|int|bool|list<string|int|bool|null>
+     * @return null|string|int|float|bool|list<string|int|float|bool|null>
      */
     private function normalizeProperty(
         Map $properties,
         string $property,
         mixed $value,
-    ): null|string|int|bool|array {
+    ): null|string|int|float|bool|array {
         return $properties
             ->get($property)
             ->map(static fn($property) => match (true) {

--- a/src/Specification/Property.php
+++ b/src/Specification/Property.php
@@ -22,17 +22,17 @@ final class Property implements Comparator
     /** @var non-empty-string */
     private string $property;
     private Sign $sign;
-    /** @var null|string|int|bool|list<string|int|bool|null> */
-    private null|string|int|bool|array $value;
+    /** @var null|string|int|float|bool|list<string|int|float|bool|null> */
+    private null|string|int|float|bool|array $value;
 
     /**
      * @param non-empty-string $property
-     * @param null|string|int|bool|list<string|int|bool|null> $value
+     * @param null|string|int|float|bool|list<string|int|float|bool|null> $value
      */
     private function __construct(
         string $property,
         Sign $sign,
-        null|string|int|bool|array $value,
+        null|string|int|float|bool|array $value,
     ) {
         $this->property = $property;
         $this->sign = $sign;
@@ -44,12 +44,12 @@ final class Property implements Comparator
      * @psalm-pure
      *
      * @param non-empty-string $property
-     * @param null|string|int|bool|list<string|int|bool|null> $value
+     * @param null|string|int|float|bool|list<string|int|float|bool|null> $value
      */
     public static function of(
         string $property,
         Sign $sign,
-        null|string|int|bool|array $value,
+        null|string|int|float|bool|array $value,
     ): self {
         return new self($property, $sign, $value);
     }
@@ -65,9 +65,9 @@ final class Property implements Comparator
     }
 
     /**
-     * @return null|string|int|bool|list<string|int|bool|null>
+     * @return null|string|int|float|bool|list<string|int|float|bool|null>
      */
-    public function value(): null|string|int|bool|array
+    public function value(): null|string|int|float|bool|array
     {
         return $this->value;
     }


### PR DESCRIPTION
## Context

Initially Formal didn't support `float`s to prevent people to use this type to store data in an unsafe way (like money for example), due to multiple bugs that may arise.

But in some cases we do need to store values as floats. For example one may want to duplicate a value to an approximation and allow to search on this approximation.

One of these cases would be a system where you let users input any _float_ value and store it as a `string` so the value never changes and duplicate this property as a `decimal` to only support search up to a certain decimal part.

## Solution

Allow `Formal\ORM\Definition\Type` to handle the `float` type.

## Notes

No _`Formal\ORM\Definition\Type\FloatType`_ is created to prevent introducing implicits in converting the floats from the storage level.

This forces users to create their own type and know which type to use in the storage.

Bugs born out of implicits can't be universally fixed by an abstraction, it's up to each app to handle them.

---

Even though the diff is small this will be released as a new major version since technically it's a BC break.