### PR TITLE
Fix CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "~8.2",
-        "innmind/immutable": "~5.4",
+        "innmind/immutable": "^5.14.1",
         "innmind/specification": "~4.1",
         "ramsey/uuid": "~4.7",
         "innmind/reflection": "~5.1",

--- a/properties/Properties.php
+++ b/properties/Properties.php
@@ -10,7 +10,7 @@ use Innmind\BlackBox\{
 
 final class Properties
 {
-    public static function any(array $properties = null): Set\Properties
+    public static function any(?array $properties = null): Set\Properties
     {
         return Set\Properties::any(
             ...\array_map(

--- a/src/Adapter/Elasticsearch.php
+++ b/src/Adapter/Elasticsearch.php
@@ -23,7 +23,7 @@ final class Elasticsearch implements Adapter
         $this->transaction = Elasticsearch\Transaction::of();
     }
 
-    public static function of(Transport $transport, Url $url = null): self
+    public static function of(Transport $transport, ?Url $url = null): self
     {
         return new self($transport, $url ?? Url::of('http://localhost:9200/'));
     }

--- a/src/Adapter/Elasticsearch/Decode.php
+++ b/src/Adapter/Elasticsearch/Decode.php
@@ -110,7 +110,7 @@ final class Decode
     /**
      * @return callable(mixed): Maybe<Aggregate>
      */
-    public function __invoke(Aggregate\Id $id = null): callable
+    public function __invoke(?Aggregate\Id $id = null): callable
     {
         $property = $this->definition->id()->property();
         /**

--- a/src/Adapter/Elasticsearch/Repository.php
+++ b/src/Adapter/Elasticsearch/Repository.php
@@ -302,7 +302,7 @@ final class Repository implements RepositoryInterface
         );
     }
 
-    public function size(Specification $specification = null): int
+    public function size(?Specification $specification = null): int
     {
         $content = null;
 
@@ -343,7 +343,7 @@ final class Repository implements RepositoryInterface
             );
     }
 
-    public function any(Specification $specification = null): bool
+    public function any(?Specification $specification = null): bool
     {
         return !$this
             ->fetch($specification, null, null, 1)
@@ -358,7 +358,7 @@ final class Repository implements RepositoryInterface
         Url $url,
         Template $path,
         string $action,
-        string $id = null,
+        ?string $id = null,
     ): Url {
         /** @var Map<non-empty-string, non-empty-string> */
         $map = Map::of(['action', $action]);

--- a/src/Adapter/Filesystem/Decode.php
+++ b/src/Adapter/Filesystem/Decode.php
@@ -39,7 +39,7 @@ final class Decode
     /**
      * @return callable(Directory): Maybe<Aggregate>
      */
-    public function __invoke(Aggregate\Id $id = null): callable
+    public function __invoke(?Aggregate\Id $id = null): callable
     {
         $property = $this->definition->id()->property();
         /** @psalm-suppress ArgumentTypeCoercion */

--- a/src/Adapter/Filesystem/Repository.php
+++ b/src/Adapter/Filesystem/Repository.php
@@ -182,14 +182,14 @@ final class Repository implements RepositoryInterface
         return $aggregates;
     }
 
-    public function size(Specification $specification = null): int
+    public function size(?Specification $specification = null): int
     {
         return $this
             ->fetch($specification, null, null, null)
             ->size();
     }
 
-    public function any(Specification $specification = null): bool
+    public function any(?Specification $specification = null): bool
     {
         return $this
             ->fetch($specification, null, null, 1)

--- a/src/Adapter/Repository.php
+++ b/src/Adapter/Repository.php
@@ -45,7 +45,7 @@ interface Repository
     /**
      * @return 0|positive-int
      */
-    public function size(Specification $specification = null): int;
+    public function size(?Specification $specification = null): int;
 
-    public function any(Specification $specification = null): bool;
+    public function any(?Specification $specification = null): bool;
 }

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -51,7 +51,7 @@ final class Decode
     /**
      * @return callable(Row): Maybe<Aggregate>
      */
-    public function __invoke(Aggregate\Id $id = null): callable
+    public function __invoke(?Aggregate\Id $id = null): callable
     {
         $idName = $this->id;
         /** @psalm-suppress MixedArgument */

--- a/src/Adapter/SQL/Decode.php
+++ b/src/Adapter/SQL/Decode.php
@@ -14,7 +14,6 @@ use Formal\AccessLayer\{
 };
 use Innmind\Immutable\{
     Maybe,
-    Set,
     Sequence,
     Str,
 };
@@ -108,27 +107,18 @@ final class Decode
                 ->collections()
                 ->map(static fn($collection) => Aggregate\Collection::of(
                     $collection->name()->alias(),
-                    Set::defer(
-                        (static function() use ($connection, $collection, $id) {
-                            // Wrapping this call in a deferred Set allows to
-                            // not immediately make the request but only when
-                            // asked.
-                            // The memoize is here to make sure the user can't
-                            // work with a partially loaded collection
-                            $entities = $connection($collection->select($id))
-                                ->map(static fn($row) => Aggregate\Collection\Entity::of(
-                                    self::properties(
-                                        $row,
-                                        $collection->columns(),
-                                    ),
-                                ))
-                                ->toList();
-
-                            foreach ($entities as $entity) {
-                                yield $entity;
-                            }
-                        })(),
-                    ),
+                    // Wrapping this in a lazy Sequence to avoid computing the
+                    // query right away but only when needed
+                    Sequence::lazy(static fn() => yield $connection($collection->select($id)))
+                        ->flatMap(static fn($rows) => $rows)
+                        ->snap() // to avoid working on partially loaded data
+                        ->map(static fn($row) => Aggregate\Collection\Entity::of(
+                            self::properties(
+                                $row,
+                                $collection->columns(),
+                            ),
+                        ))
+                        ->toSet(),
                 )),
         ));
     }

--- a/src/Adapter/SQL/MainTable.php
+++ b/src/Adapter/SQL/MainTable.php
@@ -183,7 +183,7 @@ final class MainTable
     /**
      * @internal
      */
-    public function select(Specification $specification = null): Select
+    public function select(?Specification $specification = null): Select
     {
         return match ($specification) {
             null => $this->select,
@@ -194,7 +194,7 @@ final class MainTable
     /**
      * @internal
      */
-    public function search(Specification $specification = null): Select
+    public function search(?Specification $specification = null): Select
     {
         $select = $this
             ->select
@@ -220,7 +220,7 @@ final class MainTable
     /**
      * @internal
      */
-    public function count(Specification $specification = null): Select
+    public function count(?Specification $specification = null): Select
     {
         return match ($specification) {
             null => $this->count,
@@ -288,7 +288,7 @@ final class MainTable
     /**
      * @internal
      */
-    public function delete(Specification $specification = null): Delete
+    public function delete(?Specification $specification = null): Delete
     {
         return match ($specification) {
             null => $this->delete,

--- a/src/Adapter/SQL/Repository.php
+++ b/src/Adapter/SQL/Repository.php
@@ -195,7 +195,7 @@ final class Repository implements RepositoryInterface, CrossAggregateMatching
         return Maybe::just(SubMatch::of($select));
     }
 
-    public function size(Specification $specification = null): int
+    public function size(?Specification $specification = null): int
     {
         $count = $this->mainTable->count($specification);
 
@@ -211,7 +211,7 @@ final class Repository implements RepositoryInterface, CrossAggregateMatching
             );
     }
 
-    public function any(Specification $specification = null): bool
+    public function any(?Specification $specification = null): bool
     {
         $count = $this
             ->mainTable

--- a/src/Definition/Type/MaybeType.php
+++ b/src/Definition/Type/MaybeType.php
@@ -37,7 +37,7 @@ final class MaybeType implements Type
      *
      * @return Maybe<self>
      */
-    public static function of(Types $types, Concrete $type, Contains $contains = null): Maybe
+    public static function of(Types $types, Concrete $type, ?Contains $contains = null): Maybe
     {
         return Maybe::just($type)
             ->filter(static fn($type) => $type->accepts(ClassName::of(Maybe::class)))

--- a/src/Definition/Type/Support.php
+++ b/src/Definition/Type/Support.php
@@ -38,7 +38,7 @@ final class Support
     public function __invoke(
         Types $types,
         Concrete $type,
-        Contains $contains = null,
+        ?Contains $contains = null,
     ): Maybe {
         return Maybe::just($type)
             ->filter(fn($type) => $type->accepts(ClassName::of($this->class)))

--- a/src/Definition/Types.php
+++ b/src/Definition/Types.php
@@ -32,7 +32,7 @@ final class Types
      */
     public function __invoke(
         Concrete $type,
-        Contains $contains = null,
+        ?Contains $contains = null,
     ): Maybe {
         /** @var Maybe<Type> */
         $found = Maybe::nothing();

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -30,21 +30,21 @@ final class Manager
 
     public static function of(
         Adapter $adapter,
-        Aggregates $aggregates = null,
+        ?Aggregates $aggregates = null,
     ): self {
         return new self($adapter, $aggregates ?? Aggregates::of(Types::default()));
     }
 
     public static function sql(
         Connection $connection,
-        Aggregates $aggregates = null,
+        ?Aggregates $aggregates = null,
     ): self {
         return self::of(Adapter\SQL::of($connection), $aggregates);
     }
 
     public static function filesystem(
         Storage $storage,
-        Aggregates $aggregates = null,
+        ?Aggregates $aggregates = null,
     ): self {
         return self::of(Adapter\Filesystem::of($storage), $aggregates);
     }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -198,7 +198,7 @@ final class Repository
     /**
      * @return 0|positive-int
      */
-    public function size(Specification $specification = null): int
+    public function size(?Specification $specification = null): int
     {
         return $this->adapter->size(match ($specification) {
             null => null,
@@ -206,7 +206,7 @@ final class Repository
         });
     }
 
-    public function any(Specification $specification = null): bool
+    public function any(?Specification $specification = null): bool
     {
         return $this->adapter->any(match ($specification) {
             null => null,
@@ -214,7 +214,7 @@ final class Repository
         });
     }
 
-    public function none(Specification $specification = null): bool
+    public function none(?Specification $specification = null): bool
     {
         return !$this->any($specification);
     }

--- a/src/Repository/Denormalize.php
+++ b/src/Repository/Denormalize.php
@@ -82,7 +82,7 @@ final class Denormalize
      *
      * @return callable(Aggregate): Denormalized<T>
      */
-    public function __invoke(Id $id = null): callable
+    public function __invoke(?Id $id = null): callable
     {
         $denormalize = match ($id) {
             null => $this->denormalizeId,


### PR DESCRIPTION
The code style is updated to fix PHP 8.4 deprecations. Even if it modifies an interface this should be ok (there's a low probability that anyone outside this package implemented this interface anyway).

Fixes `Set::defer()` deprecation.