### PR TITLE
Allow to use primitives in a Maybe property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `Formal\ORM\Repository::effect()`
 - `Formal\ORM\Effect`
+- `Formal\ORM\Definition\Contains\Primitive` to be used on a `Maybe` property
 
 ### Changed
 

--- a/fixtures/User.php
+++ b/fixtures/User.php
@@ -26,6 +26,9 @@ final class User
     /** @var Maybe<Str> */
     #[Contains(Str::class)]
     private Maybe $nameStr;
+    /** @var Maybe<string> */
+    #[Contains\Primitive('string')]
+    private Maybe $nameString;
     /**
      * This property is necessary for the Elasticsearch adapter that requires
      * the field being sorted on to be a keyword
@@ -77,6 +80,7 @@ final class User
         $this->wrappedCreatedAt = new CreatedAt($this->createdAtFloat);
         $this->name = $name;
         $this->nameStr = Maybe::of($name)->map(Str::of(...));
+        $this->nameString = Maybe::of($name);
         $this->sortableName = Sortable::of($name);
         $this->mainAddress = $mainAddress;
         $this->billingAddress = $billingAddress;

--- a/proofs/adapter/elasticsearch/mapping.php
+++ b/proofs/adapter/elasticsearch/mapping.php
@@ -49,6 +49,9 @@ return static function() {
                         'nameStr' => [
                             'type' => 'text',
                         ],
+                        'nameString' => [
+                            'type' => 'text',
+                        ],
                         'role' => [
                             'type' => 'text',
                         ],

--- a/proofs/adapter/sql/showCreateTable.php
+++ b/proofs/adapter/sql/showCreateTable.php
@@ -39,7 +39,7 @@ return static function() {
             $assert
                 ->expected([
                     <<<SQL
-                    CREATE TABLE  `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE  `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameString` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
                     CREATE TABLE  `user_mainAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
@@ -66,7 +66,7 @@ return static function() {
             $assert
                 ->expected([
                     <<<SQL
-                    CREATE TABLE IF NOT EXISTS `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE IF NOT EXISTS `user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameString` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                     <<<SQL
                     CREATE TABLE IF NOT EXISTS `user_mainAddress` (`aggregateId` char(36) NOT NULL  COMMENT 'UUID', `value` longtext NOT NULL  COMMENT 'TODO adjust the type depending on your use case', `id` bigint  DEFAULT NULL COMMENT 'TODO Adjust the size depending on your use case', `enabled` tinyint(1) NOT NULL  COMMENT 'Boolean', CONSTRAINT `FK_user_mainAddress` FOREIGN KEY (`aggregateId`) REFERENCES `user`(`id`) ON DELETE CASCADE, UNIQUE (`aggregateId`))
@@ -113,7 +113,7 @@ return static function() {
             $assert
                 ->expected(
                     <<<SQL
-                    CREATE TABLE  `some_user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
+                    CREATE TABLE  `some_user` (`id` char(36) NOT NULL  COMMENT 'UUID', `createdAt` char(32) NOT NULL  COMMENT 'Date with timezone down to the microsecond', `wrappedCreatedAt` decimal(65, 2) NOT NULL  , `name` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameStr` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `nameString` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', `role` longtext  DEFAULT NULL COMMENT 'TODO adjust the type depending on your use case', PRIMARY KEY (`id`))
                     SQL,
                 )
                 ->in($queries);

--- a/src/Definition/Aggregate/Parsing.php
+++ b/src/Definition/Aggregate/Parsing.php
@@ -226,9 +226,16 @@ final class Parsing
                 $property->type()->type(),
                 $property
                     ->attributes()
-                    ->find(static fn($attribute) => $attribute->class() === Contains::class)
+                    ->find(static fn($attribute) => match ($attribute->class()) {
+                        Contains::class, Contains\Primitive::class => true,
+                        default => false,
+                    })
                     ->map(static fn($attribute) => $attribute->instance())
-                    ->keep(Instance::of(Contains::class))
+                    ->keep(
+                        Instance::of(Contains::class)->or(
+                            Instance::of(Contains\Primitive::class),
+                        ),
+                    )
                     ->match(
                         static fn($contains) => $contains,
                         static fn() => null,

--- a/src/Definition/Contains/Primitive.php
+++ b/src/Definition/Contains/Primitive.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+
+namespace Formal\ORM\Definition\Contains;
+
+use Innmind\Type\Primitive as Type;
+
+/**
+ * @psalm-immutable
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class Primitive
+{
+    /**
+     * @param 'string'|'int'|'float'|'bool' $type
+     */
+    public function __construct(
+        private string $type,
+    ) {
+    }
+
+    /**
+     * @internal
+     */
+    public function type(): Type
+    {
+        return match ($this->type) {
+            'string' => Type::string(),
+            'int' => Type::int(),
+            'float' => Type::float(),
+            'bool' => Type::bool(),
+        };
+    }
+}

--- a/src/Definition/Type/MaybeType.php
+++ b/src/Definition/Type/MaybeType.php
@@ -37,8 +37,11 @@ final class MaybeType implements Type
      *
      * @return Maybe<self>
      */
-    public static function of(Types $types, Concrete $type, ?Contains $contains = null): Maybe
-    {
+    public static function of(
+        Types $types,
+        Concrete $type,
+        Contains|Contains\Primitive|null $contains = null,
+    ): Maybe {
         return Maybe::just($type)
             ->filter(static fn($type) => $type->accepts(ClassName::of(Maybe::class)))
             ->flatMap(static fn() => Maybe::of($contains))

--- a/src/Definition/Type/Support.php
+++ b/src/Definition/Type/Support.php
@@ -38,7 +38,7 @@ final class Support
     public function __invoke(
         Types $types,
         Concrete $type,
-        ?Contains $contains = null,
+        Contains|Contains\Primitive|null $contains = null,
     ): Maybe {
         return Maybe::just($type)
             ->filter(fn($type) => $type->accepts(ClassName::of($this->class)))

--- a/src/Definition/Types.php
+++ b/src/Definition/Types.php
@@ -14,13 +14,13 @@ use Innmind\Immutable\{
  */
 final class Types
 {
-    /** @var list<callable(self, Concrete, ?Contains): Maybe<Type>> */
+    /** @var list<callable(self, Concrete, Contains|Contains\Primitive|null): Maybe<Type>> */
     private array $builders;
 
     /**
      * @no-named-arguments
      *
-     * @param callable(self, Concrete, ?Contains): Maybe<Type> $builders
+     * @param callable(self, Concrete, Contains|Contains\Primitive|null): Maybe<Type> $builders
      */
     private function __construct(callable ...$builders)
     {
@@ -32,7 +32,7 @@ final class Types
      */
     public function __invoke(
         Concrete $type,
-        ?Contains $contains = null,
+        Contains|Contains\Primitive|null $contains = null,
     ): Maybe {
         /** @var Maybe<Type> */
         $found = Maybe::nothing();
@@ -48,7 +48,7 @@ final class Types
      * @no-named-arguments
      * @psalm-pure
      *
-     * @param callable(self, Concrete, ?Contains): Maybe<Type> $builders
+     * @param callable(self, Concrete, Contains|Contains\Primitive|null): Maybe<Type> $builders
      */
     public static function of(callable ...$builders): self
     {


### PR DESCRIPTION
## Request

Closes #43 

## Note

Even though this is technically a BC break as a new type can be passed as argument to types factories, users should not rely on this argument as it's not usable for the built-in `MaybeType`.

And user code should not break as the documentation say to use `Type\Support` and the class is compatible with the new signature.