### PR TITLE
Fix persisting collections with the sql adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Collections of entities weren't stored correctly by the SQL adapter
+
 ## 4.1.0 - 2025-04-30
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "~8.2",
-        "innmind/immutable": "^5.14.1",
+        "innmind/immutable": "^5.14.2",
         "innmind/specification": "~4.1",
         "ramsey/uuid": "~4.7",
         "innmind/reflection": "~5.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "~8.2",
-        "innmind/immutable": "^5.14.2",
+        "innmind/immutable": "^5.14.3",
         "innmind/specification": "~4.1",
         "ramsey/uuid": "~4.7",
         "innmind/reflection": "~5.1",


### PR DESCRIPTION
## Problem

In [`4.1.0`](https://github.com/formal-php/orm/releases/tag/4.1.0) the way collections are loaded by SQL have changed to switch [from the deprecated `Set::defer()` to the `->snap()` call](https://github.com/formal-php/orm/pull/47).

However this new `->snap()` method has a problem where it only keeps the last `Sequence` memoized data.

This means that the 2 calls below don't produce the same result:

```php
$entities = $someAggregate
    ->someCollection
    ->map(static fn($entity) => $entity)
    ->toList();
$entities = $someAggregate
    ->someCollection
    ->toList();
```

So depending on how you check the values inside the collection to modify it, it may result in unexpected behaviour (duplicated data or data loss).

### Additional problem

https://github.com/Innmind/Immutable/pull/55 the `Set` used for collections is lazy, meaning the entities are re-created each time the `Set` is unwrapped. This also leads to bugs when comparing the initial and new version of collections.

## Solution

The [problem has been fixed](https://github.com/Innmind/Immutable/pull/54) in `innmind/immutable` and released in the [`5.14.2`](https://github.com/Innmind/Immutable/releases/tag/5.14.2) and [`5.14.3`](https://github.com/Innmind/Immutable/releases/tag/5.14.3).

This PR forces the use of this new version to avoid any regression.